### PR TITLE
De-capitalize thoughtbot name

### DIFF
--- a/ecosystem/index.html
+++ b/ecosystem/index.html
@@ -48,7 +48,7 @@ title: "Ruby on Rails: Ecosystem"
           Lots of Rails consultants stand ready to help develop your application or train your
           team. <a href="http://www.koziarski.com/">Koz</a> from core works individually and
           we all like the teams from <a href="http://www.wyeworks.com/">WyeWorks</a>,
-          <a href="http://entp.com/">entp</a>, <a href="http://www.thoughtbot.com/">Thoughtbot</a>,
+          <a href="http://entp.com/">entp</a>, <a href="http://www.thoughtbot.com/">thoughtbot</a>,
           <a href="http://pivotallabs.com/">Pivotal Labs</a>, <a href="http://www.fngtps.com">Fingertips</a>,
           <a href="http://www.planetargon.com/">Planet Argon</a> and <a href="http://www.phusion.nl/">Phusion</a>.
           You can find even more consultants at <a href="http://www.workingwithrails.com/">Working with Rails</a>.


### PR DESCRIPTION
We always write `thoughtbot` in lowercase, with no capitalize at the beginning of the word.
