### PR TITLE
Fixing twitter search link

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -23,7 +23,7 @@ title: "Ruby on Rails: Community"
       <div class="section">
         <h2>Twitter & Blogs</h2>
         <p>
-          Follow along <a href="http://search.twitter.com/search?q=rails">what people are
+          Follow along <a href="https://twitter.com/search?q=rails">what people are
           saying about Rails on Twitter</a>. It's a direct hook into the pulse of Rails.
           Or follow along in what people are blogging about Rails from
           <a href="http://planetrubyonrails.com/">Planet Ruby on Rails</a>.


### PR DESCRIPTION
The old link (http://search.twitter.com/search?q=rails) doesn't work any more so I have updated it (https://twitter.com/search?q=rails).
