### PR TITLE
remove link to planetrubyonrails.com

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -27,8 +27,6 @@ title: "Ruby on Rails: Community"
         <p>
           Follow along <a href="https://twitter.com/search?q=rails" title="Rails on twitter">what people are
           saying about Rails on Twitter</a>. It’s a direct hook into the pulse of Rails.
-          Or follow along in what people are blogging about Rails from
-          <a href="http://planetrubyonrails.com/" title="Ruby on rails Blog">Planet Ruby on Rails</a>.
         </p>
       </div>
       <div class="section">


### PR DESCRIPTION
http://planetrubyonrails.com has been down for at least a month.

It was hard to find identity/contact info on the maintainers, but I think @lifo on twitter is one of the maintainers, I tried tweeting them a few weeks ago, haven't gotten a response. 

I suspect it's not coming back, but hard to be sure. 
