### PR TITLE
Update announcement to link to Rails 4.2 RC 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ title: "Ruby on Rails"
         </h2>
       </header>
       <p id="announce">
-        <a href="http://weblog.rubyonrails.org/2014/10/30/Rails-4-2-0-beta4-has-been-released/" title="Ruby on Rails Blog">Rails 4.2.0.beta4 has been released!</a>
+        <a href="http://weblog.rubyonrails.org/2014/11/28/Rails-4-2-0-rc1-has-been-released/" title="Ruby on Rails Blog">Rails 4.2.0.rc1 has been released!</a>
       </p>
       <div id="slivers">
         <ul>


### PR DESCRIPTION
The announcement on the site currently still links to Rails 4.2.0.beta4. 

Rails 4.2.0.rc1 was released a couple days ago, and the website should reflect that in its announcement section.
