### PR TITLE
"read more quotes" link hover color changed to white

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -401,6 +401,7 @@ div.section code {
 #slideshow p.more a:hover {
 	background-color: #000;
 	text-decoration: none;
+	color: #fff;
 }
 #used_by ul {
 	list-style: none;


### PR DESCRIPTION
Sorry.. It may be very insignificant but it was really annoying me. On hover, all links change color to white except this one, leaving is unreadable.
![screenshot from 2015-02-12 19 19 07](https://cloud.githubusercontent.com/assets/7680662/6168562/63d17bf6-b2ec-11e4-8455-f7dfd6a11dc8.png)




