### PR TITLE
We recommend Ruby 2.2 (not 2.1)

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -15,7 +15,7 @@ title: "Ruby on Rails: Download"
         <h2>Ruby</h2>
         <p>
           <img src="/images/pages/download/ruby.png" class="align-right" alt="Ruby">
-          We recommend <span class="highlight">Ruby 2.1</span> or newer for use with Rails.
+          We recommend <span class="highlight">Ruby 2.2</span> or newer for use with Rails.
           Rails requires Ruby 1.9.3 or newer.
         </p>
         <p>


### PR DESCRIPTION
> Rails 5.0 will target Ruby 2.2+ exclusively.

From http://weblog.rubyonrails.org/2014/12/19/Rails-4-2-final