### PR TITLE
Change our main security channel to HackerOne

### DIFF
--- a/security/index.html
+++ b/security/index.html
@@ -59,18 +59,16 @@ title: "Ruby on Rails: Security Policy"
 
     	<h2>Reporting a bug</h2>
     	<p>
-        All security bugs in rails should be reported by email to
-        <a href="mailto:security@rubyonrails.org">security@rubyonrails.org</a>. This list
-        is delivered to a subset of the <a href="http://www.rubyonrails.org/core">core team</a>
-        who handle security issues. Your email will be acknowledged within 24 hours, and you’ll
+        All security bugs in rails should be reported through our
+        <a href="https://hackerone.com/rails">bounty program page at HackerOne</a>. This will
+        deliver a message to a subset of the <a href="http://www.rubyonrails.org/core">core team</a>
+        who handle security issues. Your report will be acknowledged within 24 hours, and you’ll
         receive a more detailed response to your email within 48 hours indicating the next
         steps in handling your report.
       </p>
 
 	    <p>
-        This email address receives a large amount of spam, so be sure to use a descriptive
-        subject line to avoid having your email getting lost in the spam and your report
-        being missed. After the initial reply to your report the security team will
+        After the initial reply to your report the security team will
         endeavor to keep you informed of the progress being made towards a fix and full
         announcement. These updates will be sent at <strong>least</strong> every five days,
         in reality this is more likely to be every 24-48 hours.
@@ -82,6 +80,7 @@ title: "Ruby on Rails: Security Policy"
       </p>
 
     	<ol>
+      	<li>Send an email to the security reports list (<a href="mailto:security@rubyonrails.org">security@rubyonrails.org</a>)</li>
       	<li>Contact the current security coordinator (<a href="mailto:michael@koziarski.com">Michael Koziarski</a>) directly </li>
     		<li>Contact the back-up contact (<a href="mailto:jeremy@bitsweat.net">Jeremy Kemper</a>) directly.</li>
     		<li>Email the <a href="http://groups.google.com/group/rubyonrails-core">rails core list</a> or ask in #rails-contrib</li>


### PR DESCRIPTION
We are using h1 to track all our security issues so I think it is time to change our security page to reflect it.

cc @jeremy @NZKoz @tenderlove @matthewd