### PR TITLE
Fix missing </article></div>

### DIFF
--- a/core/alumni/index.html
+++ b/core/alumni/index.html
@@ -128,3 +128,4 @@ title: "Ruby on Rails: Core Alumni"
           with <a href="https://github.com/technoweenie" title="Technoweenie's Github account">numerous plugins</a>.
         </p>
       </div>
+    </article></div>


### PR DESCRIPTION
The [Alumni page](http://rubyonrails.org/core/alumni) was missing a closing tag:

![validator](https://cloud.githubusercontent.com/assets/10076/7446217/7cb28e70-f186-11e4-9af2-2d4d0b3dee1d.png)
