### PR TITLE
Fix dead links in Alumni page

### DIFF
--- a/core/alumni/index.html
+++ b/core/alumni/index.html
@@ -55,7 +55,7 @@ title: "Ruby on Rails: Core Alumni"
         <p>
           <strong>Jamis Buck (minam)</strong> is a repentant Java programmer who never really enjoyed Java, but who finally found web-programming joy in Rails.
           He is an avid Ruby programmer, having contributed several packages to the community (including <a href="http://net-ssh.rubyforge.org/" title="Net::SSH gem">Net::SSH</a>,
-          <a href="http://net-ssh.rubyforge.org/sftp/faq.html">Net::SFTP</a>, <a href="http://syntax.rubyforge.org/">Syntax</a>,
+          <a href="http://net-ssh.github.io/sftp/v1/faq.html">Net::SFTP</a>, <a href="http://syntax.rubyforge.org/">Syntax</a>,
           <a href="http://sqlite-ruby.rubyforge.org/" title="Sqlite Ruby">sqlite-ruby</a>, <a href="http://sqlite-ruby.rubyforge.org/sqlite3/faq.html" title="Sqlite3 Ruby">sqlite3-ruby</a>,
           <a href="http://manuals.rubyonrails.org/read/book/17">SwitchTower</a> and others).
           He lives with his wife Tarasine and four children in Idaho.
@@ -83,14 +83,14 @@ title: "Ruby on Rails: Core Alumni"
       <div class="section">
         <img src="/images/pages/core/alumni/florian.jpg" width="150" height="172" class="biopic" alt="Florian Weber's photo">
         <p>
-          <strong>Florian Weber (csshsh)</strong> began using Rails in early 2004.  Since then he’s played an integral role in several Rails-based projects.  He developed the <span class="caps">CMS</span> and webshop for <a href="http://www.bellybutton.de" title="Bellybutton Webshop">bellybutton.de</a>, and later worked on <a href="http://www.odeo.com" title="Odeo Website">Odeo</a>.  In Spring 2006 he began working on <a href="http://twitter.com" title="Twitter website">Twitter</a> as lead developer.  At the moment, he is living in Berlin, Germany and working as a software developer.
+          <strong>Florian Weber (csshsh)</strong> began using Rails in early 2004.  Since then he’s played an integral role in several Rails-based projects.  He developed the <span class="caps">CMS</span> and webshop for <a href="http://www.bellybutton.de" title="Bellybutton Webshop">bellybutton.de</a>, and later worked on Odeo.  In Spring 2006 he began working on <a href="http://twitter.com" title="Twitter website">Twitter</a> as lead developer.  At the moment, he is living in Berlin, Germany and working as a software developer.
         </p>
       </div>
       <div class="section">
         <img src="/images/pages/core/alumni/sam.jpg" width="150" height="160" class="biopic" alt="Sam Stephenson's photo">
         <p>
           <strong>Sam Stephenson (sam-)</strong> is a fan of dynamic languages who found Ruby just six months before Rails’ first release. In February of 2005,
-          he released the <a href="http://prototype.conio.net/" title="Prototype: Ajax foundation in rails">Prototype</a> JavaScript library, which provides the foundation for Ajax support in Rails. Sam lives in Chicago,
+          he released the <a href="http://prototypejs.org" title="Prototype: Ajax foundation in rails">Prototype</a> JavaScript library, which provides the foundation for Ajax support in Rails. Sam lives in Chicago,
           works for <a href="http://www.basecamp.com" title="Basecamp website">Basecamp</a>, and tumblelogs on <a href="http://project.ioni.st/" title="Projectionist website">Projectionist</a>.
         </p>
       </div>
@@ -115,7 +115,7 @@ title: "Ruby on Rails: Core Alumni"
           Once found, he quickly ported the bits and pieces of his code over to Ruby which later became
           the first rails based e-commerce store “Snowdevil”. Tobi is a partner at <a href="http://jadedpixel.com/" title="JadedPixel official site">JadedPixel</a> and is
           frantically working on <a href="http://shopify.com/" title="E-commerce platform">Shopify</a> which is the continuation of the Snowdevil code base.
-          Over time, Tobi released many open source projects such as <a href="http://typo.leetsoft.com/" Title="Typo official site">Typo</a>, <a href="http://www.hieraki.org/" Title="Hieraki website">Hieraki</a>,
+          Over time, Tobi released many open source projects such as <a href="http://typo.leetsoft.com/" Title="Typo official site">Typo</a>, Hieraki,
           and <a href="http://www.liquidmarkup.org" title="Ruby library for rendering safe templates">Liquid</a>.
         </p>
       </div><div class="section">


### PR DESCRIPTION
Just to confirm, here are the links:

- Sftp: [dead](http://net-ssh.rubyforge.org/sftp/faq.html) | [alive](http://net-ssh.github.io/sftp/v1/faq.html)
- Odeo: [dead](http://www.odeo.com)
- Prototype: [dead](http://prototype.conio.net/) | [alive](http://prototypejs.org)
- Hieraki: [dead](http://www.hieraki.org/)