### PR TITLE
Fix: show full logo at the top of the Quotes page

### DIFF
--- a/quotes/index.html
+++ b/quotes/index.html
@@ -6,8 +6,9 @@ title: "Ruby on Rails: Quotes"
       <header>
         <h1>Smart people saying nice things</h1>
         <h2>
-          Ego-inflation galore. This is where we collect quotes from smart,<br />
-          famous, and/or funny people saying nice things about Rails.
+          Ego-inflation galore.<br />
+          This is where we collect quotes from smart, famous,<br />
+          and/or funny people saying nice things about Rails.
         </h2>
       </header>
       <blockquote>


### PR DESCRIPTION
Because of the current layout, each page header must be divided in three lines in order for the Rails logo to be fully displayed. However, the head of [the Quotes page](http://rubyonrails.org/quotes) only occupies two lines, resulting in this:

![before](https://cloud.githubusercontent.com/assets/10076/7446355/a6712dc6-f18a-11e4-94cd-30edd0a623f7.png)

As for the other pages, I have added a `<br />`, so now the header looks like this:

![after](https://cloud.githubusercontent.com/assets/10076/7446358/b84119e4-f18a-11e4-80a2-283629011c7b.png)


