### PR TITLE
Fix embedded font in 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,46 +1,11 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <title>Ruby on Rails: Not Found</title>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=800">
-    <link href="/styles.css" type="text/css" media="screen" rel="stylesheet">
-    <script type="text/javascript">
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', 'UA-1959218-2']);
-      _gaq.push(['_trackPageview']);
-
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-    </script>
-  </head>
-  <body>
-    <div id="navigation" class="nav"><nav>
-      <a href="/">Overview</a> |
-      <a href="/download/">Download</a> |
-      <a href="/deploy/">Deploy</a> |
-      <a href="https://github.com/rails/rails/issues">Bugs/Patches</a> |
-      <a href="/screencasts/">Screencasts</a> |
-      <a href="/documentation/">Documentation</a> |
-      <a href="/community/">Community</a> |
-      <a href="http://weblog.rubyonrails.org">Blog</a>
-    </nav></div>
-    <div id="content"><section>
-      <div id="article" class="overview"><article>
-        <header>
-          <h1>Web development that doesn’t hurt</h1>
-          <h2>Ruby on Rails<sup><small>&reg;</small></sup> is an open-source web framework that’s optimized for programmer happiness and sustainable productivity. It lets you write beautiful code by favoring convention over configuration.</h2>
-        </header>
-        <p class="missing">Sorry! We couldn’t find what you were looking for.</p>
-      </article></div>
-    </section></div>
-    <div id="footer" class="footer"><footer>
-      <p>“Rails”, “Ruby on Rails”, and the Rails logo are registered trademarks of David Heinemeier Hansson. All rights reserved.</p>
-      <p>Rails is released under the <a href="http://www.opensource.org/licenses/mit-license.php">MIT license</a>. Ruby under the <a href="http://www.ruby-lang.org/en/LICENSE.txt">Ruby License</a>.</p>
-      <p id="sponsored_by"><span>Sponsored by</span> <a href="http://www.basecamp.com/"><img src="/images/basecamp.png" width="100" height="24" alt="Basecamp"></a>
-    </footer></div>
-  </body>
-</html>
+---
+layout: default
+title: "Ruby on Rails: Not Found"
+---
+    <div id="article" class="overview"><article>
+      <header>
+        <h1>Web development that doesn’t hurt</h1>
+        <h2>Ruby on Rails<sup><small>&reg;</small></sup> is an open-source web framework that’s optimized for programmer happiness and sustainable productivity. It lets you write beautiful code by favoring convention over configuration.</h2>
+      </header>
+      <p class="missing">Sorry! We couldn’t find what you were looking for.</p>
+    </article></div>


### PR DESCRIPTION
The 404 page was not showing the correct embedded font because it was not requiring TypeKit.

Since the 404 page has the same layout as any other page, using the 'default' layout rather than re-writing the whole HTML structure fixes the problem.