### PR TITLE
Remove links to broken .rubyonrails.org subdomains

### DIFF
--- a/core/alumni/index.html
+++ b/core/alumni/index.html
@@ -57,7 +57,7 @@ title: "Ruby on Rails: Core Alumni"
           He is an avid Ruby programmer, having contributed several packages to the community (including <a href="http://net-ssh.rubyforge.org/" title="Net::SSH gem">Net::SSH</a>,
           <a href="http://net-ssh.github.io/sftp/v1/faq.html">Net::SFTP</a>, <a href="http://syntax.rubyforge.org/">Syntax</a>,
           <a href="http://sqlite-ruby.rubyforge.org/" title="Sqlite Ruby">sqlite-ruby</a>, <a href="http://sqlite-ruby.rubyforge.org/sqlite3/faq.html" title="Sqlite3 Ruby">sqlite3-ruby</a>,
-          <a href="http://manuals.rubyonrails.org/read/book/17">SwitchTower</a> and others).
+          SwitchTower and others).
           He lives with his wife Tarasine and four children in Idaho.
         </p>
       </div>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -45,7 +45,7 @@ title: "Ruby on Rails: Documentation"
       <div class="section">
         <h2>Talking<br>foxes?</h2>
         <p>
-          <a href="http://media.rubyonrails.org/videos/rails_take2_with_sound.mov" class="nohover align-right" title="video about rails"><img src="/images/pages/documentation/chunkybacon.gif" class="bordered" alt="Chunky bacon"></a>
+          <img src="/images/pages/documentation/chunkybacon.gif" class="bordered align-right" alt="Chunky bacon">
           <a href="http://mislav.uniqpath.com/poignant-guide/" title="Programming guide about ruby">why’s (poignant) guide to Ruby</a>
           is unlike any other guide to programming you have ever read. It features talking foxes,
           bizarre sidebars, and more crazy humor than most people can handle without loud chuckles.

--- a/screencasts/index.html
+++ b/screencasts/index.html
@@ -22,12 +22,6 @@ title: "Ruby on Rails: Screencasts"
           a free online course that provides you five labs, each with a short video followed
           by a series of exercises where you get to code Rails immediately in your browser.
         </p>
-        <p class="footnote">
-          If you’re interested in the history of Rails, we also still have the screencasts
-          made for <a href="http://media.rubyonrails.org/video/rails_blog_2.mov" title="Video about history of rails 2">Ruby on
-          Rails 2</a>, <a href="http://media.rubyonrails.org/video/rails-0-5.mov" title="Video about history of rails 0.5">Ruby on
-          Rails 0.5</a> and for <a href="http://media.rubyonrails.org/video/rails_take2_with_sound.mov" title="Video about history of rails 1.0">Ruby on Rails 1.0</a>.
-        </p>
       </div>
       <div class="section">
         <a href="http://rails4.codeschool.com/videos" class="screencast" title="Rails 4 videos">


### PR DESCRIPTION
Namely: media.rubyonrails.org and manuals.rubyonrails.org
Closes #48
