### PR TITLE
Make the H2 of Overview look like any other page

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,9 @@ body {
 	margin: 0px;
 	padding: 0px;
 }
+sup {
+  line-height: 0;
+}
 a img {
 	border: none;
 }


### PR DESCRIPTION
All the pages have the same style of headers: the Rails logo on the left, a black H1 and three rows of grey H2.

However, the / and /404.html are slightly different because they use a `<sup>` tag that pushes the H2 text below the Rails logo.

This commit fixes the difference.