### PR TITLE
Uniform the layout of /security with the site

### DIFF
--- a/security/index.html
+++ b/security/index.html
@@ -2,7 +2,16 @@
 layout: default
 title: "Ruby on Rails: Security Policy"
 ---
-    <div id="article" class="security"><article>
+    <div id="article"><article>
+      <header>
+        <h1>Security policy</h1>
+        <h2>
+          Rails takes web security very seriously.<br />
+          If you found a vulnerability in Ruby on Rails, follow<br />
+          these steps to safely report the issue to the core team.
+        </h2>
+      </header>
+      <div class="section">
       <h2>Supported versions</h2>
     	<p>
         Support of the Rails framework is divided into four groups: New features, bug fixes,
@@ -159,4 +168,5 @@ title: "Ruby on Rails: Security Policy"
         If you have any suggestions to improve this policy, please send an email to
         <a href="mailto:security@rubyonrails.org">security@rubyonrails.org</a>.
       </p>
+      </div>
     </article></div>

--- a/styles.css
+++ b/styles.css
@@ -31,6 +31,9 @@ a.align-center {
 a.align-center img {
 	display: block;
 }
+ul, ol {
+  margin-left: 250px;
+}
 img.bordered {
 	background-color: #fff;
 	border: 1px solid #CCC;
@@ -67,11 +70,11 @@ div.section h3 {
 	line-height: 140%;
 }
 div.section p {
-	font-family: Georgia;
-	font-size: 18px;
-	line-height: 140%;
-	margin: 0px 0px 25px 250px;
-	width: 450px;
+  font-family: Georgia;
+  font-size: 18px;
+  line-height: 140%;
+  margin: 0px 0px 25px 250px;
+  width: 450px;
 }
 div.section h2.small {
 	font-size: 20px;
@@ -364,34 +367,4 @@ div.section code {
 #article.quotes blockquote p cite {
 	font-size: 14px;
 	color: #a69e8a;
-}
-/* Security Policy */
-#article.security {
-	margin: 50px auto 30px;
-	width: 700px;
-}
-#article.security h2 {
-	font-weight: bold;
-	text-transform: uppercase;
-	font-size: 20px;
-	font-family: Arial, Helvetica, sans-serif;
-	text-align: center;
-	margin: 40px 0px 15px 0px;
-}
-#article.security h3 {
-	color: #900;
-	font-family: Georgia;
-	font-size: 18px;
-	margin: 0;
-	line-height: 140%;
-}
-#article.security p,
-#article.security ol {
-	font-family: Georgia;
-	font-size: 18px;
-	line-height: 140%;
-	margin: 0px 0px 25px 0px;
-}
-#article.security ol li {
-	margin: 0px 0px 10px 0px;
 }


### PR DESCRIPTION
Every page of the website has the same layout (header/body) except for the Security page. This commit fixes that, styling the body as the rest of the site and adding the following header:

>Security policy
>
>Did you find a security vulnerability in Ruby on Rails?
>Follow these steps to safely report the issue to the core team.
>You might even be eligible for a bounty.

The only content added is the header; let me know if you agree with the text above.
Please be aware that the Security page is not linked anywhere from the rest of the site.

It is linked only from [this paragraph in the guides](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#special-treatment-for-security-issues), so the header should somehow follow that paragraph which says:

> 1.3 Special Treatment for Security Issues
> Please do not report security vulnerabilities with public GitHub issue reports. The Rails security policy page details the procedure to follow for security issues.