### PR TITLE
Don’t duplicate layout elements -- move them to the default layout

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,10 +1,8 @@
 ---
 title: "Not Found"
+header: "Web development that doesn’t hurt"
+subheader_1: "Ruby on Rails<sup><small>&reg;</small></sup> is an open-source web framework that’s optimized for"
+subheader_2: "programmer happiness and sustainable productivity. It lets you write"
+subheader_3: "beautiful code by favoring convention over configuration."
 ---
-    <div id="article"><article>
-      <header>
-        <h1>Web development that doesn’t hurt</h1>
-        <h2>Ruby on Rails<sup><small>&reg;</small></sup> is an open-source web framework that’s optimized for programmer happiness and sustainable productivity. It lets you write beautiful code by favoring convention over configuration.</h2>
-      </header>
       <p class="missing">Sorry! We couldn’t find what you were looking for.</p>
-    </article></div>

--- a/404.html
+++ b/404.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: "Ruby on Rails: Not Found"
 ---
     <div id="article"><article>

--- a/404.html
+++ b/404.html
@@ -1,5 +1,5 @@
 ---
-title: "Ruby on Rails: Not Found"
+title: "Not Found"
 ---
     <div id="article"><article>
       <header>

--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,7 @@ exclude:
   - CNAME
 gems:
   - jekyll-sitemap
+defaults:
+  -
+    values:
+      layout:  "default"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>{{ page.title }}</title>
+    <title>Ruby on Rails{% if page.title %}: {{ page.title }}{% endif %}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=800">
     <link href="/styles.css" type="text/css" media="screen" rel="stylesheet">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,17 @@
   <body>
 {% include navigation.html %}
     <div role="main"><section>
-{{ content }}
+      <div id="article"><article>
+        <header>
+          <h1>{{ page.header }}</h1>
+          <h2>
+            {{ page.subheader_1 }}<br />
+            {{ page.subheader_2 }}<br />
+            {{ page.subheader_3 }}
+          </h2>
+        </header>
+        {{ content }}
+      </article></div>
     </section></div>
 {% include footer.html %}
   </body>

--- a/community/index.html
+++ b/community/index.html
@@ -1,15 +1,10 @@
 ---
 title: "Community"
+header: "Become part of the Rails family"
+subheader_1: "The community around Ruby on Rails is full of nice people who"
+subheader_2: "want to help others learn. Become a part of the family, learn from"
+subheader_3: "others, and give something back when you can."
 ---
-    <div id="article"><article>
-      <header>
-        <h1>Become part of the Rails family</h1>
-        <h2>
-          The community around Ruby on Rails is full of nice people who<br />
-          want to help others learn. Become a part of the family, learn from<br />
-          others, and give something back when you can.
-        </h2>
-      </header>
       <div class="section">
         <h2>Mailing lists</h2>
         <p>
@@ -37,4 +32,3 @@ title: "Community"
           patch to Rails itself.
         </p>
       </div>
-    </article></div>

--- a/community/index.html
+++ b/community/index.html
@@ -1,5 +1,5 @@
 ---
-title: "Ruby on Rails: Community"
+title: "Community"
 ---
     <div id="article"><article>
       <header>

--- a/community/index.html
+++ b/community/index.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: "Ruby on Rails: Community"
 ---
     <div id="article"><article>

--- a/core/alumni/index.html
+++ b/core/alumni/index.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: "Ruby on Rails: Core Alumni"
 ---
     <div id="article"><article>

--- a/core/alumni/index.html
+++ b/core/alumni/index.html
@@ -1,5 +1,5 @@
 ---
-title: "Ruby on Rails: Core Alumni"
+title: "Core Alumni"
 ---
     <div id="article"><article>
       <header>

--- a/core/alumni/index.html
+++ b/core/alumni/index.html
@@ -1,15 +1,10 @@
 ---
 title: "Core Alumni"
+header: "The core alumni"
+subheader_1: "Retired members of the core team who are no longer"
+subheader_2: "active in the day-to-day improvement of the framework."
+subheader_3: "We thank you dearly for your service over the years."
 ---
-    <div id="article"><article>
-      <header>
-        <h1>The core alumni</h1>
-        <h2>
-          Retired members of the core team who are no longer<br />
-          active in the day-to-day improvement of the framework.<br />
-          We thank you dearly for your service over the years.
-        </h2>
-      </header>
       <div class="section">
         <img src="/images/pages/core/yehuda.jpg" class="biopic" alt="Yehuda Katz's photo">
         <p>
@@ -127,4 +122,3 @@ title: "Core Alumni"
           with <a href="https://github.com/technoweenie" title="Technoweenie's Github account">numerous plugins</a>.
         </p>
       </div>
-    </article></div>

--- a/core/index.html
+++ b/core/index.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: "Ruby on Rails: Core"
 ---
     <div id="article"><article>

--- a/core/index.html
+++ b/core/index.html
@@ -1,5 +1,5 @@
 ---
-title: "Ruby on Rails: Core"
+title: "Core"
 ---
     <div id="article"><article>
       <header>

--- a/core/index.html
+++ b/core/index.html
@@ -1,15 +1,10 @@
 ---
 title: "Core"
+header: "The core team"
+subheader_1: "These are the top producers that were given the keys to the"
+subheader_2: "source repository after months or even years of loyal service."
+subheader_3: "They are presented in order of acceptance to the team."
 ---
-    <div id="article"><article>
-      <header>
-        <h1>The core team</h1>
-        <h2>
-          These are the top producers that were given the keys to the<br />
-          source repository after months or even years of loyal service.<br />
-          They are presented in order of acceptance to the team.
-        </h2>
-      </header>
       <div class="section">
         <img src="/images/pages/core/david.jpg" class="biopic" alt="David Heinemeier's photo">
         <p>
@@ -156,4 +151,3 @@ title: "Core"
           <em>Rails core members who are no longer active in the day-to-day stuff have been immortalized as <a href="/core/alumni/" title="Core alumni page">core alumni</a></em>.
         </p>
       </div>
-    </article></div>

--- a/deploy/index.html
+++ b/deploy/index.html
@@ -1,15 +1,10 @@
 ---
 title: "Deploy"
+header: "Deploying Ruby on Rails is easy"
+subheader_1: "Taking your Rails application live has never been easier."
+subheader_2: "Thanks to the rise of Passenger aka mod_rails,"
+subheader_3: "launching is now almost as easy as developing."
 ---
-    <div id="article"><article>
-      <header>
-        <h1>Deploying Ruby on Rails is easy</h1>
-        <h2>
-          Taking your Rails application live has never been easier.<br />
-          Thanks to the rise of Passenger aka mod_rails,<br />
-          launching is now almost as easy as developing.
-        </h2>
-      </header>
       <div class="section">
         <h2>Passenger<br>aka mod_rails</h2>
         <p>
@@ -44,4 +39,3 @@ title: "Deploy"
           While Rails hosting is now common place, there’s a handful of dedicated Rails hosting companies that have been around for a long time and supporting the community: <a href="http://www.heroku.com/" title="Heroku website">Heroku</a>, <a href="http://railsmachine.com/" title="Rails Machine website">Rails Machine</a>, <a href="http://www.brightbox.co.uk/" title=" Btightbox website">Brightbox</a>, and <a href="http://www.engineyard.com/" title="Engine Yard Website">Engine Yard</a>. If you’re just looking for a VPS, we recommend <a href="http://www.rackspace.com" title="Rackspace website">Rackspace</a> (who gracefully donated slices for us to run Rails infrastructure on) or <a href="http://www.linode.com/" title="Linode website">Linode</a>.
         </p>
       </div>
-    </article></div>

--- a/deploy/index.html
+++ b/deploy/index.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: "Ruby on Rails: Deploy"
 ---
     <div id="article"><article>

--- a/deploy/index.html
+++ b/deploy/index.html
@@ -1,5 +1,5 @@
 ---
-title: "Ruby on Rails: Deploy"
+title: "Deploy"
 ---
     <div id="article"><article>
       <header>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -1,5 +1,5 @@
 ---
-title: "Ruby on Rails: Documentation"
+title: "Documentation"
 ---
     <div id="article"><article>
       <header>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: "Ruby on Rails: Documentation"
 ---
     <div id="article"><article>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -1,15 +1,10 @@
 ---
 title: "Documentation"
+header: "Learn all about Ruby on Rails"
+subheader_1: "We have everything you need to become an expert with Rails,"
+subheader_2: "including books, tutorials, manuals, and lots of"
+subheader_3: "open-source examples."
 ---
-    <div id="article"><article>
-      <header>
-        <h1>Learn all about Ruby on Rails</h1>
-        <h2>
-          We have everything you need to become an expert with Rails,<br />
-          including books, tutorials, manuals, and lots of<br />
-          open-source examples.
-        </h2>
-      </header>
       <div class="section">
         <h2>Guides</h2>
         <p>
@@ -50,4 +45,3 @@ title: "Documentation"
           bizarre sidebars, and more crazy humor than most people can handle without loud chuckles.
         </p>
       </div>
-    </article></div>

--- a/download/index.html
+++ b/download/index.html
@@ -1,5 +1,5 @@
 ---
-title: "Ruby on Rails: Download"
+title: "Download"
 ---
     <div id="article"><article>
       <header>

--- a/download/index.html
+++ b/download/index.html
@@ -1,15 +1,10 @@
 ---
 title: "Download"
+header: "Get Ruby on Rails in no time"
+subheader_1: "Rails is low on dependencies and prides itself on shipping with"
+subheader_2: "most everything you need in the box. To get started, just install"
+subheader_3: "Ruby, the language, and RubyGems, the package manager."
 ---
-    <div id="article"><article>
-      <header>
-        <h1>Get Ruby on Rails in no time</h1>
-        <h2>
-          Rails is low on dependencies and prides itself on shipping with<br />
-          most everything you need in the box. To get started, just install<br />
-          Ruby, the language, and RubyGems, the package manager.
-        </h2>
-      </header>
       <div class="section">
         <h2>Ruby</h2>
         <p>
@@ -64,4 +59,3 @@ title: "Download"
           For a full-on IDE, check out <a href="http://www.jetbrains.com/ruby/index.html" title="Ruby on rails IDE">JetBrains RubyMine</a>.
         </p>
       </div>
-    </article></div>

--- a/download/index.html
+++ b/download/index.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: "Ruby on Rails: Download"
 ---
     <div id="article"><article>

--- a/index.html
+++ b/index.html
@@ -1,14 +1,9 @@
 ---
+header: "Web development that doesn’t hurt"
+subheader_1: "Ruby on Rails<sup><small>&reg;</small></sup> is an open-source web framework that’s optimized"
+subheader_2: "for programmer happiness and sustainable productivity. It lets you"
+subheader_3: "write beautiful code by favoring convention over configuration."
 ---
-    <div id="article"><article>
-      <header>
-        <h1>Web development that doesn’t hurt</h1>
-        <h2>
-          Ruby on Rails<sup><small>&reg;</small></sup> is an open-source web framework that’s optimized<br />
-          for programmer happiness and sustainable productivity. It lets you<br />
-          write beautiful code by favoring convention over configuration.
-        </h2>
-      </header>
       <p id="announce">
         <a href="http://weblog.rubyonrails.org/2014/12/19/Rails-4-2-final/" title="Ruby on Rails Blog">Rails 4.2.0 has been released!</a>
       </p>
@@ -150,4 +145,3 @@
           <a href="http://contributors.rubyonrails.org" title="Access to the list of contributors">more than 3,700 contributors</a>.
         </p>
       </div>
-    </article></div>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: "Ruby on Rails"
 ---
     <div id="article"><article>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,4 @@
 ---
-title: "Ruby on Rails"
 ---
     <div id="article"><article>
       <header>

--- a/quotes/index.html
+++ b/quotes/index.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: "Ruby on Rails: Quotes"
 ---
     <div id="article" class="quotes"><article>

--- a/quotes/index.html
+++ b/quotes/index.html
@@ -1,15 +1,10 @@
 ---
 title: "Quotes"
+header: "Smart people saying nice things"
+subheader_1: "Ego-inflation galore."
+subheader_2: "This is where we collect quotes from smart, famous,"
+subheader_3: "and/or funny people saying nice things about Rails."
 ---
-    <div id="article"><article>
-      <header>
-        <h1>Smart people saying nice things</h1>
-        <h2>
-          Ego-inflation galore.<br />
-          This is where we collect quotes from smart, famous,<br />
-          and/or funny people saying nice things about Rails.
-        </h2>
-      </header>
       <blockquote>
         <p>
           “Rails is the most well thought-out web development framework I’ve ever used.<br>
@@ -74,4 +69,3 @@ title: "Quotes"
         </p>
         <p><cite>– Yukihiro Matsumoto, Creator of Ruby</cite></p>
       </blockquote>
-    </article></div>

--- a/quotes/index.html
+++ b/quotes/index.html
@@ -1,5 +1,5 @@
 ---
-title: "Ruby on Rails: Quotes"
+title: "Quotes"
 ---
     <div id="article" class="quotes"><article>
       <header>

--- a/quotes/index.html
+++ b/quotes/index.html
@@ -1,7 +1,7 @@
 ---
 title: "Quotes"
 ---
-    <div id="article" class="quotes"><article>
+    <div id="article"><article>
       <header>
         <h1>Smart people saying nice things</h1>
         <h2>

--- a/screencasts/index.html
+++ b/screencasts/index.html
@@ -1,15 +1,10 @@
 ---
 title: "Screencasts"
+header: "Show, don’t tell: Seeing is believing"
+subheader_1: "Lean back and enjoy the shows, but be careful: Going back to your"
+subheader_2: "former treadmill after being exposed to these movies can prove"
+subheader_3: "exceedingly painful. Don’t say we didn’t try to warn you."
 ---
-    <div id="article"><article>
-      <header>
-        <h1>Show, don’t tell: Seeing is believing</h1>
-        <h2>
-          Lean back and enjoy the shows, but be careful: Going back to your<br />
-          former treadmill after being exposed to these movies can prove<br />
-          exceedingly painful. Don’t say we didn’t try to warn you.
-        </h2>
-      </header>
       <div class="section">
         <a href="http://railsforzombies.org" class="screencast" title="Code school about Rails">
           <img width="190" height="150" src="/images/pages/screencasts/Rails_for_Zombies-2.jpg" alt="Rails for zombies">
@@ -56,4 +51,3 @@ title: "Screencasts"
           and they’re done by the same fantastic Ryan Bates that did the video above.
         </p>
       </div>
-    </article></div>

--- a/screencasts/index.html
+++ b/screencasts/index.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: "Ruby on Rails: Screencasts"
 ---
     <div id="article"><article>

--- a/screencasts/index.html
+++ b/screencasts/index.html
@@ -1,5 +1,5 @@
 ---
-title: "Ruby on Rails: Screencasts"
+title: "Screencasts"
 ---
     <div id="article"><article>
       <header>

--- a/security/index.html
+++ b/security/index.html
@@ -1,15 +1,10 @@
 ---
 title: "Security Policy"
+header: "Security policy"
+subheader_1: "Rails takes web security very seriously."
+subheader_2: "If you found a vulnerability in Ruby on Rails, follow"
+subheader_3: "these steps to safely report the issue to the core team."
 ---
-    <div id="article"><article>
-      <header>
-        <h1>Security policy</h1>
-        <h2>
-          Rails takes web security very seriously.<br />
-          If you found a vulnerability in Ruby on Rails, follow<br />
-          these steps to safely report the issue to the core team.
-        </h2>
-      </header>
       <div class="section">
       <h2>Supported versions</h2>
     	<p>
@@ -168,4 +163,3 @@ title: "Security Policy"
         <a href="mailto:security@rubyonrails.org">security@rubyonrails.org</a>.
       </p>
       </div>
-    </article></div>

--- a/security/index.html
+++ b/security/index.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: "Ruby on Rails: Security Policy"
 ---
     <div id="article"><article>

--- a/security/index.html
+++ b/security/index.html
@@ -1,5 +1,5 @@
 ---
-title: "Ruby on Rails: Security Policy"
+title: "Security Policy"
 ---
     <div id="article"><article>
       <header>

--- a/styles.css
+++ b/styles.css
@@ -304,12 +304,9 @@ div.section code {
 	margin: 0px;
 	position: absolute;
 	width: 700px;
+	font-size: 16px;
 }
-#slideshow blockquote p {
-	margin: 0px;
-}
-#slideshow blockquote p cite {
-	font-size: 14px;
+#slideshow cite {
 	color: #464242;
 }
 #slideshow p.more {
@@ -351,20 +348,19 @@ div.section code {
 }
 
 /* Quotes */
-#article.quotes blockquote {
-	font-family: Georgia;
-	font-size: 18px;
-	line-height: 140%;
-	margin: 0px auto 25px;
-	text-align: center;
-	width: 700px;
-	padding: 0px;
-	position: relative;
+blockquote {
+  font-family: Georgia;
+  font-size: 18px;
+  text-align: center;
+  margin: 0px auto 25px;
+  line-height: 140%;
 }
-#article.quotes blockquote p {
+
+blockquote p {
 	margin: 0px;
 }
-#article.quotes blockquote p cite {
-	font-size: 14px;
+
+cite {
+  font-size: 14px;
 	color: #a69e8a;
 }


### PR DESCRIPTION
Another PR that does not change the content of the site, just removes duplication.

Taking advantage of the fact that all pages now have the same layout, elements like title, headers and sub-headers can now be specified in a single file (_layouts/default.html), using Jekyll front matter to modify only the content page by page.