### PR TITLE
Responsive navbar

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,12 +1,25 @@
-    <div id="navigation" role="navigation">
-      <nav>
-        <a href="/" title="Ruby on Rails Main">Overview</a> |
-        <a href="/download/" title="Download the Ruby on Rails latest stable version">Download</a> |
-        <a href="/deploy/" title="How to deploy Ruby on Rails">Deploy</a> |
-        <a href="https://github.com/rails/rails/issues" title="Bugs/Parches report of Ruby on Rails github">Bugs/Patches</a> |
-        <a href="/screencasts/" title="Some screencasts about Rails">Screencasts</a> |
-        <a href="/documentation/" title="APIs, Books and Guides documentation about Ruby on Rails">Documentation</a> |
-        <a href="/community/" title="Join to the Ruby on Rails Community">Community</a> |
-        <a href="http://weblog.rubyonrails.org" title="Ruby on Rails blog post">Blog</a>
-      </nav>
+<nav class="navbar navbar-default" role="navigation">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-collapse">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
     </div>
+
+    <div class="collapse navbar-collapse" id="bs-collapse">
+      <ul class="nav navbar-nav">
+        <li><a href="/" title="Ruby on Rails Main">Overview</a></li>
+        <li><a href="/download/" title="Download the Ruby on Rails latest stable version">Download</a></li>
+        <li><a href="/deploy/" title="How to deploy Ruby on Rails">Deploy</a></li>
+        <li><a href="https://github.com/rails/rails/issues" title="Bugs/Parches report of Ruby on Rails github">Bugs/Patches</a></li>
+        <li><a href="/screencasts/" title="Some screencasts about Rails">Screencasts</a></li>
+        <li><a href="/documentation/" title="APIs, Books and Guides documentation about Ruby on Rails">Documentation</a></li>
+        <li><a href="/community/" title="Join to the Ruby on Rails Community">Community</a></li>
+        <li><a href="http://weblog.rubyonrails.org" title="Ruby on Rails blog post">Blog</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" media="screen" rel="stylesheet" type="text/css" />
     <link href="/styles.css" type="text/css" media="screen" rel="stylesheet">
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js" type="text/javascript"></script>
+    <script src="//netdna.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js" type="text/javascript"></script>
     <script src="//use.typekit.net/iay1mwo.js"></script>
     <script>try{Typekit.load();}catch(e){}</script>
 {% include google.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,8 @@
     <title>Ruby on Rails{% if page.title %}: {{ page.title }}{% endif %}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=800">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <link href="//netdna.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" media="screen" rel="stylesheet" type="text/css" />
     <link href="/styles.css" type="text/css" media="screen" rel="stylesheet">
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
     <script src="//use.typekit.net/iay1mwo.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -362,3 +362,15 @@ cite {
   font-size: 14px;
 	color: #a69e8a;
 }
+
+/* The following rules override values set by Bootstrap CSS, ensuring that
+   the site looks the same whether or not Bootstrap CSS is loaded. */
+
+*                                                   {-webkit-box-sizing: content-box; -moz-box-sizing: content-box; box-sizing: content-box}
+a                                                   {text-decoration: underline}
+code                                                {background-color: transparent; color: #000; padding-left: 0; padding-right: 0}
+pre                                                 {background-color: transparent; border: 0; padding: 0}
+h3                                                  {font-weight: bold}
+img                                                 {vertical-align: baseline}
+ul, ol                                              {margin-bottom: 14px}
+blockquote                                          {border-left: 0; padding: 0}

--- a/styles.css
+++ b/styles.css
@@ -128,30 +128,12 @@ div.section code {
 	font-size: 16px;
 	font-weight: bold;
 }
-#navigation {
-	width: 726px;
-	margin: 15px auto 10px;
-	font-size: 10px;
-	line-height: 12px;
-	text-align: center;
-}
-#navigation a {
-	color: #000;
-	font-weight: bold;
-	font-size: 11px;
-	text-decoration: underline;
-}
-#navigation a:hover {
-	background-color: #000;
-	color: #fff;
-	text-decoration: none;
-}
 #article {
 	padding: 0px 0px 20px 0px;
 }
 #article header {
 	background: url(images/rails.png) no-repeat left top;
-	margin: 50px auto 32px;
+	margin: 25px auto 32px;
 	width: 606px;
 	padding-left: 100px;
 	text-align: center;
@@ -374,3 +356,29 @@ h3                                                  {font-weight: bold}
 img                                                 {vertical-align: baseline}
 ul, ol                                              {margin-bottom: 14px}
 blockquote                                          {border-left: 0; padding: 0}
+
+/* TYPOGRAPHY */
+.navbar-nav                                         {font-size: 11px}
+.navbar-nav a                                       {font-weight: bold}
+
+/* COLOR */
+.navbar-default                                     {background-color: transparent; border-color: transparent}
+.navbar-default .navbar-nav>li>a                    {color: #000}
+.navbar-default .navbar-nav>li>a:focus,
+.navbar-default .navbar-nav>li>a:hover              {color: #fff; background-color: #333}
+.navbar-collapse.in                                 {border-bottom-color: #e7e7e7; border-bottom-style: solid}
+.collapse:not(.in) .navbar-nav li:not(:last-child)  {border-right-color: #000; border-right-style: solid}
+
+/* VERTICAL LAYOUT */
+.navbar-nav>li>a                                    {padding-top: 0; padding-bottom: 0}
+.navbar-nav li                                      {margin-top: 10px; margin-bottom: 15px}
+.navbar-collapse.in                                 {border-bottom-width: 1px}
+
+/* HORIZONTAL LAYOUT */
+.navbar-nav>li>a                                    {padding-left: 0; padding-right: 0}
+.collapse:not(.in) .navbar-nav li                   {padding-left: 5px; padding-right: 5px}
+.collapse:not(.in) .navbar-nav li:not(:last-child)  {border-right-width: 1px}
+@media (min-width: 768px) { /* center the navbar, see stackoverflow.com/a/18778769 */
+  .navbar .navbar-nav                               {display: inline-block; float: none; vertical-align: top}
+  .navbar .navbar-collapse                          {text-align: center}
+}


### PR DESCRIPTION
Please read the messages of the two commits to fully understand this PR:

* [first commit](https://github.com/rails/rails.github.com/commit/c6c5c7709ef1d9d2cd11d5b47560357cfe45cbe2)
* [second commit](https://github.com/rails/rails.github.com/commit/2892c0c9e785feb3359fafc476c303559052f7da)

The following screenshots are to show the navbar before/after the PR:

* In normal-sized windows, the difference is minimum (I had to replace the hard-coded `|` characters between navbar elements with actual borders)
* In small-sized windows, the navbar is not truncated anymore, but replaced with a collapsable dropdown menu. Clicking on the toggle shows and hides the menu.
* The rest of the website is not affected. If you prefer, I can make a single PR that makes the entire site responsive, but for now I'm doing step-by-step PRs as suggested by @rafaelfranca 

![nav-before-after-loop](https://cloud.githubusercontent.com/assets/10076/7480113/0a67706a-f31b-11e4-89e8-ff0fba1191e8.gif)
![nav-small-before-after-loop](https://cloud.githubusercontent.com/assets/10076/7480118/19042bcc-f31b-11e4-99f1-de2b0cb12944.gif)
![dropdown](https://cloud.githubusercontent.com/assets/10076/7480119/1acce908-f31b-11e4-84f0-b21ac8bc1cb9.png)
