### PR TITLE
Responsive footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,5 @@
-    <div id="footer" class="container"><footer>
+    <footer class="container">
       <p>“Rails”, “Ruby on Rails”, and the Rails logo are registered trademarks of David Heinemeier Hansson. All rights reserved.</p>
       <p>Rails is released under the <a href="http://www.opensource.org/licenses/mit-license.php" title="About MIT License">MIT license</a>. Ruby under the <a href="http://www.ruby-lang.org/en/LICENSE.txt" title="Text of Ruby License">Ruby License</a>.</p>
       <p id="sponsored_by"><span>Extracted from</span> <a href="http://www.basecamp.com/" title="Basecamp: Project management app" ><img src="/images/basecamp.png" width="100" height="24" alt="Basecamp logo"></a>
-    </footer></div>
+    </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-    <div id="footer"><footer>
+    <div id="footer" class="container"><footer>
       <p>“Rails”, “Ruby on Rails”, and the Rails logo are registered trademarks of David Heinemeier Hansson. All rights reserved.</p>
       <p>Rails is released under the <a href="http://www.opensource.org/licenses/mit-license.php" title="About MIT License">MIT license</a>. Ruby under the <a href="http://www.ruby-lang.org/en/LICENSE.txt" title="Text of Ruby License">Ruby License</a>.</p>
       <p id="sponsored_by"><span>Extracted from</span> <a href="http://www.basecamp.com/" title="Basecamp: Project management app" ><img src="/images/basecamp.png" width="100" height="24" alt="Basecamp logo"></a>

--- a/styles.css
+++ b/styles.css
@@ -180,10 +180,8 @@ div.section code {
 #footer {
 	color: #666;
 	font-size: 11px;
-	margin: 0px auto;
-	padding: 0px 0px 44px 0px;
+	padding-bottom: 44px;
 	text-align: center;
-	width: 726px;
 }
 #footer p {
 	margin: 12px 0px;

--- a/styles.css
+++ b/styles.css
@@ -177,23 +177,6 @@ div.section code {
 	text-align: center;
 	width: 700px;
 }
-#footer {
-	color: #666;
-	font-size: 11px;
-	padding-bottom: 44px;
-	text-align: center;
-}
-#footer p {
-	margin: 12px 0px;
-}
-#footer p a {
-	color: #000;
-}
-#footer p a:hover {
-	background-color: #333;
-	color: #fff;
-	text-decoration: none;
-}
 #sponsored_by {
 	margin: 17px 0px !important;
 }
@@ -356,13 +339,17 @@ ul, ol                                              {margin-bottom: 14px}
 blockquote                                          {border-left: 0; padding: 0}
 
 /* TYPOGRAPHY */
-.navbar-nav                                         {font-size: 11px}
+.navbar-nav, footer                                 {font-size: 11px}
 .navbar-nav a                                       {font-weight: bold}
+footer a:focus, footer a:hover                      {text-decoration: none}
+footer                                              {text-align: center}
 
 /* COLOR */
+footer                                              {color: #666}
 .navbar-default                                     {background-color: transparent; border-color: transparent}
-.navbar-default .navbar-nav>li>a                    {color: #000}
+.navbar-default .navbar-nav>li>a, footer a          {color: #000}
 .navbar-default .navbar-nav>li>a:focus,
+footer a:focus, footer a:hover,
 .navbar-default .navbar-nav>li>a:hover              {color: #fff; background-color: #333}
 .navbar-collapse.in                                 {border-bottom-color: #e7e7e7; border-bottom-style: solid}
 .collapse:not(.in) .navbar-nav li:not(:last-child)  {border-right-color: #000; border-right-style: solid}
@@ -371,6 +358,8 @@ blockquote                                          {border-left: 0; padding: 0}
 .navbar-nav>li>a                                    {padding-top: 0; padding-bottom: 0}
 .navbar-nav li                                      {margin-top: 10px; margin-bottom: 15px}
 .navbar-collapse.in                                 {border-bottom-width: 1px}
+footer                                              {padding-bottom: 44px}
+footer p                                            {margin-top: 12px; margin-bottom: 12px}
 
 /* HORIZONTAL LAYOUT */
 .navbar-nav>li>a                                    {padding-left: 0; padding-right: 0}


### PR DESCRIPTION
Wrap the footer in a container, so that the footer looks the same in normal-sized windows, but the text now wraps correctly in narrow windows. Here's the before/after:

![footer-wide-loop](https://cloud.githubusercontent.com/assets/10076/7481262/a7fc6990-f323-11e4-89df-afb573e13387.gif)
![footer-narrow-loop](https://cloud.githubusercontent.com/assets/10076/7481263/a7fe5700-f323-11e4-904c-eca52c70b220.gif)



Also optimizes DOM/CSS by replacing

```html
<div id="footer" class="container"><footer>
...
</footer></div>
```

with

```html
<footer class="container">
...
</footer>
```

and updating the CSS file accordingly, reusing styles already declared for the navbar (such as: links are black and become white with black background on hover). 