### PR TITLE
Responsive header

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,6 +1,9 @@
 <nav class="navbar navbar-default" role="navigation">
   <div class="container-fluid">
     <div class="navbar-header">
+      <a class="navbar-brand" href="/" title="Ruby on Rails Main">
+        <img alt="Brand" src="/images/rails.png">
+      </a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-collapse">
         <span class="sr-only">Toggle navigation</span>
         <span class="icon-bar"></span>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,7 @@
 {% include navigation.html %}
     <div role="main"><section>
       <div id="article"><article>
-        <header class="container">
+        <header class="container text-center">
           <h1>{{ page.header }}</h1>
           <h2>
             {{ page.subheader_1 }}<br class="hidden-xs" />

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,11 +17,11 @@
 {% include navigation.html %}
     <div role="main"><section>
       <div id="article"><article>
-        <header>
+        <header class="container">
           <h1>{{ page.header }}</h1>
           <h2>
-            {{ page.subheader_1 }}<br />
-            {{ page.subheader_2 }}<br />
+            {{ page.subheader_1 }}<br class="hidden-xs" />
+            {{ page.subheader_2 }}<br class="hidden-xs" />
             {{ page.subheader_3 }}
           </h2>
         </header>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -29,8 +29,8 @@ subheader_3: "open-source examples."
         </p>
         <p class="centered">
           <a href="http://pragprog.com/titles/rails4/agile-web-development-with-rails" class="nohover align-center" title="Agile Web
-          Development with Rails 4 ebook and paper book "><img src="/images/pages/documentation/awdr4.png" class="bordered" width="140" height="150" alt="Agile web development with rails book"></a>
-          <a href="http://pragprog.com/book/jvrails/crafting-rails-applications" class="nohover" title="Crafting Rails 4 Applications ebook and paper book"><img src="/images/pages/documentation/cra-mini.png" class="bordered" width="140" height="150" alt="Crafting rails applications book"></a>
+          Development with Rails 4 ebook and paper book "><img src="/images/pages/documentation/awdr4.png" class="bordered" width="144" height="154" alt="Agile web development with rails book"></a>
+          <a href="http://pragprog.com/book/jvrails/crafting-rails-applications" class="nohover" title="Crafting Rails 4 Applications ebook and paper book"><img src="/images/pages/documentation/cra-mini.png" class="bordered" width="144" height="154" alt="Crafting rails applications book"></a>
         </p>
         <p>
           See all the other <a href="http://www.amazon.com/gp/search?ie=UTF8&amp;keywords=ruby%20on%20rails&amp;tag=rubonrai-20&amp;index=books&amp;linkCode=ur2&amp;camp=1789&amp;creative=9325" title=" Related Searches about ruby on rails">Ruby on Rails books</a> at Amazon.

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ subheader_3: "write beautiful code by favoring convention over configuration."
         <ul>
           <li role="listitem">
             <h2>Get Excited</h2>
-            <a href="/screencasts/" title="Click for screencasts"><img src="/images/pages/overview/screencasts2.png" class="bordered" width="140" height="150" alt="Image representing a block of code"></a>
+            <a href="/screencasts/" title="Click for screencasts"><img src="/images/pages/overview/screencasts2.png" class="bordered" width="144" height="154" alt="Image representing a block of code"></a>
             <p><a href="/screencasts/" title="Some screencasts about Rails">Screencasts &amp; presentations</a></p>
           </li>
           <li role="listitem">
@@ -21,7 +21,7 @@ subheader_3: "write beautiful code by favoring convention over configuration."
           </li>
           <li role="listitem">
             <h2>Get Better</h2>
-            <a href="/documentation/" title="APIs, Books and Guides documentation about Ruby on Rails"><img src="/images/pages/documentation/awdr4.png" width="140" height="150" class="bordered" alt="Image showing the cover of the book Agile development with rails"></a>
+            <a href="/documentation/" title="APIs, Books and Guides documentation about Ruby on Rails"><img src="/images/pages/documentation/awdr4.png" width="144" height="154" class="bordered" alt="Image showing the cover of the book Agile development with rails"></a>
             <p><a href="/documentation/" title="APIs, Books and Guides documentation about Ruby on Rails">API, Guides, Books</a></p>
           </li>
           <li role="listitem">
@@ -120,19 +120,19 @@ subheader_3: "write beautiful code by favoring convention over configuration."
         <p>Tens of thousands of Rails applications are already live. People are using Rails in the tiniest part-time operations to the biggest companies.</p>
         <ul>
           <li>
-            <a href="http://www.basecamp.com/?source=rails" title="Basecamp: Project management app"><img width="175" height="110" src="/images/applications/bcx.gif" alt="Image showing Basecamp's index page" class="bordered"></a>
+            <a href="http://www.basecamp.com/?source=rails" title="Basecamp: Project management app"><img width="179" height="114" src="/images/applications/bcx.gif" alt="Image showing Basecamp's index page" class="bordered"></a>
             <p><a href="http://www.basecamp.com/?source=rails" title="Basecamp: Project management app">Basecamp</a>: The original Rails app.</p>
           </li>
           <li>
-            <a href="http://twitter.com/" title="Twitter website"><img width="175" height="110" src="/images/applications/twitter.jpg" alt="Image showing Twitter's index page" class="bordered"></a>
+            <a href="http://twitter.com/" title="Twitter website"><img width="179" height="114" src="/images/applications/twitter.jpg" alt="Image showing Twitter's index page" class="bordered"></a>
             <p><a href="http://twitter.com/" title="Twitter website">Twitter</a>: Stay connected.</p>
           </li>
           <li>
-            <a href="http://github.com/" title="Github build software better, together"><img width="175" height="110" src="/images/applications/github.jpg" alt="Image showing GitHub's index page" class="bordered"></a>
+            <a href="http://github.com/" title="Github build software better, together"><img width="179" height="114" src="/images/applications/github.jpg" alt="Image showing GitHub's index page" class="bordered"></a>
             <p><a href="http://github.com/" title="Github build software better, together">GitHub</a>: Git repo hosting.</p>
           </li>
           <li>
-            <a href="http://www.shopify.com/" title="Shopify: e-commerce platform"><img width="175" height="110" src="/images/applications/shopify.jpg" alt="Shopify" class="bordered"></a>
+            <a href="http://www.shopify.com/" title="Shopify: e-commerce platform"><img width="179" height="114" src="/images/applications/shopify.jpg" alt="Shopify" class="bordered"></a>
             <p><a href="http://www.shopify.com/" title="Shopify: e-commerce platform">Shopify</a>: E-commerce made easy.</p>
           </li>
         </ul>

--- a/screencasts/index.html
+++ b/screencasts/index.html
@@ -7,7 +7,7 @@ subheader_3: "exceedingly painful. Don’t say we didn’t try to warn you."
 ---
       <div class="section">
         <a href="http://railsforzombies.org" class="screencast" title="Code school about Rails">
-          <img width="190" height="150" src="/images/pages/screencasts/Rails_for_Zombies-2.jpg" alt="Rails for zombies">
+          <img width="198" height="158" src="/images/pages/screencasts/Rails_for_Zombies-2.jpg" alt="Rails for zombies">
         </a>
         <h3>Learning Rails the Zombie Way</h3>
         <p>
@@ -25,7 +25,7 @@ subheader_3: "exceedingly painful. Don’t say we didn’t try to warn you."
       </div>
       <div class="section">
         <a href="http://rails4.codeschool.com/videos" class="screencast" title="Rails 4 videos">
-          <img width="190" height="150" src="/images/pages/screencasts/rails4_zombie_outlaws.jpg" alt="Rails 4 zombie outlaws">
+          <img width="198" height="158" src="/images/pages/screencasts/rails4_zombie_outlaws.jpg" alt="Rails 4 zombie outlaws">
         </a>
         <h3>Rails 4: Zombie Outlaws</h3>
         <p>
@@ -41,7 +41,7 @@ subheader_3: "exceedingly painful. Don’t say we didn’t try to warn you."
       </div>
       <div class="section">
         <a href="http://railscasts.com" class="screencast" title="Click to access to Rails Casts">
-          <img width="190" height="150" src="/images/pages/screencasts/railscasts.png" alt="Rails casts">
+          <img width="198" height="158" src="/images/pages/screencasts/railscasts.png" alt="Rails casts">
         </a>
         <h3>More free screencasts from Railscasts.com</h3>
         <p>

--- a/styles.css
+++ b/styles.css
@@ -107,8 +107,8 @@ div.section img.biopic {
 	border: 2px solid #ccc;
 	padding: 2px;
 	float: left;
-	width: 150px;
-	height: 172px;
+	width: 158px;
+	height: 180px;
 	margin: 0px 0px 10px 40px;
 }
 div.section a.screencast {
@@ -132,7 +132,7 @@ div.section code {
 	padding: 0px 0px 20px 0px;
 }
 #article header {
-	margin: 25px auto 32px;
+	margin: 27px auto 32px;
 	width: 606px;
 	text-align: center;
 }
@@ -158,6 +158,7 @@ div.section code {
   #article header {
     background: url(images/rails.png) no-repeat left top;
     padding-left: 100px;
+    width: 706px;
   }
 }
 #article p a,
@@ -257,7 +258,7 @@ div.section code {
 #slideshow {
 	font-family: Georgia;
 	font-size: 16px;
-	height: 132px;
+	height: 162px;
 	line-height: 140%;
 	margin: 0px auto 30px;
 	text-align: center;
@@ -333,7 +334,6 @@ cite {
 /* The following rules override values set by Bootstrap CSS, ensuring that
    the site looks the same whether or not Bootstrap CSS is loaded. */
 
-*                                                   {-webkit-box-sizing: content-box; -moz-box-sizing: content-box; box-sizing: content-box}
 a                                                   {text-decoration: underline}
 code                                                {background-color: transparent; color: #000; padding-left: 0; padding-right: 0}
 pre                                                 {background-color: transparent; border: 0; padding: 0}

--- a/styles.css
+++ b/styles.css
@@ -133,7 +133,6 @@ div.section code {
 }
 #article header {
 	margin: 27px auto 32px;
-	width: 606px;
 	text-align: center;
 }
 #article header h1 {
@@ -156,9 +155,8 @@ div.section code {
 }
 @media (min-width: 768px) {
   #article header {
-    background: url(images/rails.png) no-repeat left top;
-    padding-left: 100px;
-    width: 706px;
+    background: url(images/rails.png) no-repeat 22px top;
+    padding-left: 115px;
   }
 }
 #article p a,
@@ -375,4 +373,7 @@ footer p                                            {margin-top: 12px; margin-bo
   .navbar .navbar-nav                               {display: inline-block; float: none; vertical-align: top}
   .navbar .navbar-collapse                          {text-align: center}
   .navbar-brand                                     {display: none}
+}
+@media (min-width:992px)  { /* Reduce width on big screens */
+  .container                                        {width: 750px}
 }

--- a/styles.css
+++ b/styles.css
@@ -140,7 +140,7 @@ div.section code {
   font-family: "expressway",sans-serif;
   font-style: normal;
   font-weight: 700;
-	font-size: 38px;
+	font-size: 31px;
   line-height: 30px;
   color: #000000;
 }
@@ -149,7 +149,7 @@ div.section code {
   font-family: "expressway",sans-serif;
   font-style: normal;
   font-weight: 400;
-	font-size: 21px;
+	font-size: 18px;
 	line-height: 24px;
 	color: #999999;
 }
@@ -158,6 +158,8 @@ div.section code {
     background: url(images/rails.png) no-repeat 22px top;
     padding-left: 115px;
   }
+  #article header h1 {font-size: 38px}
+  #article header h2 {font-size: 21px}
 }
 #article p a,
 #article ol a,

--- a/styles.css
+++ b/styles.css
@@ -132,10 +132,8 @@ div.section code {
 	padding: 0px 0px 20px 0px;
 }
 #article header {
-	background: url(images/rails.png) no-repeat left top;
 	margin: 25px auto 32px;
 	width: 606px;
-	padding-left: 100px;
 	text-align: center;
 }
 #article header h1 {
@@ -155,6 +153,12 @@ div.section code {
 	font-size: 21px;
 	line-height: 24px;
 	color: #999999;
+}
+@media (min-width: 768px) {
+  #article header {
+    background: url(images/rails.png) no-repeat left top;
+    padding-left: 100px;
+  }
 }
 #article p a,
 #article ol a,
@@ -360,6 +364,8 @@ footer a:focus, footer a:hover,
 .navbar-collapse.in                                 {border-bottom-width: 1px}
 footer                                              {padding-bottom: 44px}
 footer p                                            {margin-top: 12px; margin-bottom: 12px}
+.navbar-brand                                       {padding-top: 8px}
+.navbar-brand img                                   {height: 34px}
 
 /* HORIZONTAL LAYOUT */
 .navbar-nav>li>a                                    {padding-left: 0; padding-right: 0}
@@ -368,4 +374,5 @@ footer p                                            {margin-top: 12px; margin-bo
 @media (min-width: 768px) { /* center the navbar, see stackoverflow.com/a/18778769 */
   .navbar .navbar-nav                               {display: inline-block; float: none; vertical-align: top}
   .navbar .navbar-collapse                          {text-align: center}
+  .navbar-brand                                     {display: none}
 }

--- a/styles.css
+++ b/styles.css
@@ -131,36 +131,6 @@ div.section code {
 #article {
 	padding: 0px 0px 20px 0px;
 }
-#article header {
-	margin: 27px auto 32px;
-	text-align: center;
-}
-#article header h1 {
-	margin: 0 auto 12px;
-  font-family: "expressway",sans-serif;
-  font-style: normal;
-  font-weight: 700;
-	font-size: 31px;
-  line-height: 30px;
-  color: #000000;
-}
-#article header h2 {
-	margin: 0 auto;
-  font-family: "expressway",sans-serif;
-  font-style: normal;
-  font-weight: 400;
-	font-size: 18px;
-	line-height: 24px;
-	color: #999999;
-}
-@media (min-width: 768px) {
-  #article header {
-    background: url(images/rails.png) no-repeat 22px top;
-    padding-left: 115px;
-  }
-  #article header h1 {font-size: 38px}
-  #article header h2 {font-size: 21px}
-}
 #article p a,
 #article ol a,
 #article ul a {
@@ -343,15 +313,23 @@ ul, ol                                              {margin-bottom: 14px}
 blockquote                                          {border-left: 0; padding: 0}
 
 /* TYPOGRAPHY */
+header                                              {font-family: "expressway", sans-serif; font-style: normal}
 .navbar-nav, footer                                 {font-size: 11px}
 .navbar-nav a                                       {font-weight: bold}
 footer a:focus, footer a:hover                      {text-decoration: none}
 footer                                              {text-align: center}
+h1                                                  {font-size: 31px; line-height: 30px; font-weight: 700}
+header h2                                           {font-size: 18px; line-height: 24px; font-weight: 400}
+@media (min-width: 768px) {
+  h1                                                {font-size: 38px}
+  header h2                                         {font-size: 21px}
+}
 
 /* COLOR */
 footer                                              {color: #666}
+header h2                                           {color: #999}
 .navbar-default                                     {background-color: transparent; border-color: transparent}
-.navbar-default .navbar-nav>li>a, footer a          {color: #000}
+.navbar-default .navbar-nav>li>a, footer a, h1      {color: #000}
 .navbar-default .navbar-nav>li>a:focus,
 footer a:focus, footer a:hover,
 .navbar-default .navbar-nav>li>a:hover              {color: #fff; background-color: #333}
@@ -363,9 +341,13 @@ footer a:focus, footer a:hover,
 .navbar-nav li                                      {margin-top: 10px; margin-bottom: 15px}
 .navbar-collapse.in                                 {border-bottom-width: 1px}
 footer                                              {padding-bottom: 44px}
-footer p                                            {margin-top: 12px; margin-bottom: 12px}
+footer p                                            {margin-top: 12px}
+footer p, h1                                        {margin-bottom: 12px}
 .navbar-brand                                       {padding-top: 8px}
 .navbar-brand img                                   {height: 34px}
+header                                              {margin-top: 27px; margin-bottom: 32px}
+h1, header h2                                       {margin-top: 0}
+header h2                                           {margin-bottom: 0}
 
 /* HORIZONTAL LAYOUT */
 .navbar-nav>li>a                                    {padding-left: 0; padding-right: 0}
@@ -375,6 +357,7 @@ footer p                                            {margin-top: 12px; margin-bo
   .navbar .navbar-nav                               {display: inline-block; float: none; vertical-align: top}
   .navbar .navbar-collapse                          {text-align: center}
   .navbar-brand                                     {display: none}
+  header.container                                  {background: url(images/rails.png) no-repeat 22px top; padding-left: 115px;}
 }
 @media (min-width:992px)  { /* Reduce width on big screens */
   .container                                        {width: 750px}


### PR DESCRIPTION
Please, read the individual commit messages in order to fully understand this PR.

After this PR, the headers and sub-headers look the same on normal-sized pages, but instead of being cropped on small screens, they now adapt by means of:

* not overflowing the width of the screen
* reducing the font-size 
* moving the Rails logo from the header to the subnav

As an example, this is how headers and subheaders of the home page look now:

![screen shot 2015-05-05 at 3 06 28 pm](https://cloud.githubusercontent.com/assets/10076/7483961/76293fd2-f338-11e4-9411-92b200a3e054.png)

and this is how they look after this PR:

![screen shot 2015-05-05 at 3 03 20 pm](https://cloud.githubusercontent.com/assets/10076/7483964/81a5bb2e-f338-11e4-8f3a-70897b6ba98b.png)

---

For completeness, here are all the other headers/sub-headers when viewed at smaller sizes:

![screen shot 2015-05-05 at 3 03 25 pm](https://cloud.githubusercontent.com/assets/10076/7483975/99b31cde-f338-11e4-8cbf-0773ebdb7ae9.png)
![screen shot 2015-05-05 at 3 03 18 pm](https://cloud.githubusercontent.com/assets/10076/7483974/99b1eeb8-f338-11e4-9487-d5f7008a4c7e.png)
![screen shot 2015-05-05 at 3 03 17 pm](https://cloud.githubusercontent.com/assets/10076/7483977/99b71fc8-f338-11e4-9521-15ddbadb3c4d.png)
![screen shot 2015-05-05 at 3 03 15 pm](https://cloud.githubusercontent.com/assets/10076/7483976/99b5b17e-f338-11e4-8920-e0e970288def.png)
![screen shot 2015-05-05 at 3 03 13 pm](https://cloud.githubusercontent.com/assets/10076/7483978/99ba2dee-f338-11e4-9be8-c5afd23d412c.png)
![screen shot 2015-05-05 at 3 03 11 pm](https://cloud.githubusercontent.com/assets/10076/7483979/99bcbe60-f338-11e4-99dd-ea67f7474f3b.png)
![screen shot 2015-05-05 at 3 03 07 pm](https://cloud.githubusercontent.com/assets/10076/7483981/99c502be-f338-11e4-8ba2-c71fa382f317.png)
![screen shot 2015-05-05 at 3 03 02 pm](https://cloud.githubusercontent.com/assets/10076/7483982/99c92786-f338-11e4-92af-924090dc07f8.png)
