### PR TITLE
Responsive design: all two-column sections

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,4 +5,6 @@ subheader_1: "Ruby on Rails<sup><small>&reg;</small></sup> is an open-source web
 subheader_2: "programmer happiness and sustainable productivity. It lets you write"
 subheader_3: "beautiful code by favoring convention over configuration."
 ---
+    <div class="container-fluid text-center">
       <p class="missing">Sorry! We couldn’t find what you were looking for.</p>
+    </div>

--- a/community/index.html
+++ b/community/index.html
@@ -5,8 +5,12 @@ subheader_1: "The community around Ruby on Rails is full of nice people who"
 subheader_2: "want to help others learn. Become a part of the family, learn from"
 subheader_3: "others, and give something back when you can."
 ---
-      <div class="section">
+    <div class="container">
+      <div class="section row">
+        <div class="col-sm-4">
         <h2>Mailing lists</h2>
+        </div>
+        <div class="col-sm-8">
         <p>
           <a href="http://groups.google.com/group/rubyonrails-talk" title="Google group for Ruby on Rails users">Ruby on Rails Talk</a> is where
           Rails users come to <span class="highlight">seek help, announce projects, and discuss</span>
@@ -15,20 +19,32 @@ subheader_3: "others, and give something back when you can."
           Finally, there’s the <a href="http://groups.google.com/group/rubyonrails-security" title="Security annoucements for Ruby on Rails">security
           announcement list</a> for critical patches.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <h2>Twitter &amp; Blogs</h2>
+        </div>
+        <div class="col-sm-8">
         <p>
           Follow along <a href="https://twitter.com/search?q=rails" title="Rails on twitter">what people are
           saying about Rails on Twitter</a>. It’s a direct hook into the pulse of Rails.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <h2>IRC</h2>
+        </div>
+        <div class="col-sm-8">
         <p>
           Sometimes it’s just easier to get help or <span class="highlight">discuss matters
           in real time</span>. The <em>#rubyonrails</em> channel on <em>irc.freenode.net</em>
           allows for just that. Try <em>#rails-contrib</em> if you want help or discuss your
           patch to Rails itself.
         </p>
+        </div>
       </div>
+    </div>

--- a/core/alumni/index.html
+++ b/core/alumni/index.html
@@ -5,8 +5,12 @@ subheader_1: "Retired members of the core team who are no longer"
 subheader_2: "active in the day-to-day improvement of the framework."
 subheader_3: "We thank you dearly for your service over the years."
 ---
-      <div class="section">
+    <div class="container">
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/yehuda.jpg" class="biopic" alt="Yehuda Katz's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Yehuda Katz</strong> is a member of the Ember.js and
           jQuery Core Teams; during the daytime, he works at <a href="http://www.tilde.io" title="Tilde website">Tilde</a>.
@@ -14,9 +18,14 @@ subheader_3: "We thank you dearly for your service over the years."
           and is a contributor to Ruby in Practice. He blogs at <a href="http://yehudakatz.com" title="Yehuda Katz's blog">yehudakatz.com</a>
           and can be found on Twitter as <a href="http://www.twitter.com/wycats" title="follow @wycats on Twitter">@wycats</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/jonleighton.jpg" alt="Jon Leighton's Photo" class="biopic">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Jon Leighton</strong> is Tech Director at <a href="https://loco2.com/" title="Loco2's website">Loco2</a>.
           During his time on the core team he did a bunch of work on Active Record and created the
@@ -24,28 +33,48 @@ subheader_3: "We thank you dearly for your service over the years."
           of time <a href="http://climberjon.wordpress.com/" title="Read more about Jon's climbing adventures">rock climbing</a>. You can follow
           <a href="https://twitter.com/jonleighton" title="Follow to @jonleighton on Twitter">@jonleighton</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/pic1218916611.jpg" alt="Josh Peek's Photo" class="biopic">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Josh Peek (joshp)</strong> has been working with almost all parts of Rails. A lot of work spent on performance and thread safety for Action Pack. Josh works at <a href="http://www.github.com" title="GitHub website">GitHub</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/carl.jpg" alt="Carl Lerche's Photo" class="biopic">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Carl Lerche</strong> is a Platform Architect at <a href="http://www.strobecorp.com" title="Strobe Website">Strobe</a>, where he runs a top-notch product engineering team and hacks on Strobe Platform. He’s been programming for as long as he can remember, and focused on Ruby development since 2005. He is a member of the Ruby on Rails Core Team and speaker at numerous industry conferences and events. He lives in downtown San Francisco and has a fondness for quality Belgian Beers... and pie. Follow him on Twitter at <a href="http://www.twitter.com/carllerche" title="Follow to @carllerche on twitter">@carllerche</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/pratik.jpg" alt="Pratik Naik's Photo" class="biopic">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Pratik Naik (lifo)</strong> stumbled upon Rails back in 2006 while in search
           for a better web framework after 2 painful years with perl/mod_perl. He hasn’t looked back since then. Currently located in London, he is an employee of <a href="http://www.basecamp.com/" title="Basecamp website">Basecamp</a> and maintains a personal blog at <a href="http://m.onkey.org" title="Patrik Naik's personal blog">http://m.onkey.org</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/alumni/jamis.jpg" alt="Jamis Buck's Photo" class="biopic">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Jamis Buck (minam)</strong> is a repentant Java programmer who never really enjoyed Java, but who finally found web-programming joy in Rails.
           He is an avid Ruby programmer, having contributed several packages to the community (including <a href="http://net-ssh.rubyforge.org/" title="Net::SSH gem">Net::SSH</a>,
@@ -54,9 +83,14 @@ subheader_3: "We thank you dearly for your service over the years."
           <a href="http://manuals.rubyonrails.org/read/book/17">SwitchTower</a> and others).
           He lives with his wife Tarasine and four children in Idaho.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/alumni/marcel_molina.jpg" class="biopic" alt="Marcel Molina Jr.'s photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Marcel Molina Jr. (noradio)</strong> is a language enthusiast
           who went from being a literature major to a programmer.  In his transition from
@@ -64,46 +98,76 @@ subheader_3: "We thank you dearly for your service over the years."
           dynamic, pragmatic and “humane”.  And then came along Rails… Marcel works at
           <a href="http://twitter.com/" title="Twitter website">twitter</a> and tumblelogs at <a href="http://project.ioni.st/" title="Projectionist page">Projectionist</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/alumni/nicholas.jpg" class="biopic" alt="Nicholas Seckar's Photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Nicholas Seckar (ulysses)</strong> is a student and software engineer living in Toronto, Canada.
           Nicholas has been contributing to Ruby and Rails since Fall 2004, with numerous bug fixes and new features such as Routing.
           He has been a developer on <a href="http://www.measuremap.com" title="Measure map website ">Measure Map</a> since August 2005. He is currently completing his undergraduate degree
           at the University of Toronto, while also working for Google in their Toronto engineering department.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/alumni/florian.jpg" class="biopic" alt="Florian Weber's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Florian Weber (csshsh)</strong> began using Rails in early 2004.  Since then he’s played an integral role in several Rails-based projects.  He developed the <span>CMS</span> and webshop for <a href="http://www.bellybutton.de" title="Bellybutton Webshop">bellybutton.de</a>, and later worked on Odeo.  In Spring 2006 he began working on <a href="http://twitter.com" title="Twitter website">Twitter</a> as lead developer.  At the moment, he is living in Berlin, Germany and working as a software developer.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/alumni/sam.jpg" class="biopic" alt="Sam Stephenson's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Sam Stephenson (sam-)</strong> is a fan of dynamic languages who found Ruby just six months before Rails’ first release. In February of 2005,
           he released the <a href="http://prototypejs.org" title="Prototype: Ajax foundation in rails">Prototype</a> JavaScript library, which provides the foundation for Ajax support in Rails. Sam lives in Chicago,
           works for <a href="http://www.basecamp.com" title="Basecamp website">Basecamp</a>, and tumblelogs on <a href="http://project.ioni.st/" title="Projectionist website">Projectionist</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/alumni/scott.jpg" class="biopic" alt="Scott Barron's page">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Scott Barron (htonl)</strong> was set to swear off computers forever and become a plumber when Rails was released.
           He immediately found salvation in the warm embrace of Ruby and has never looked back. He currently practices
           Rails by working for <a href="http://www.theedgecase.com/" title="Edge case company Website">EdgeCase</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/alumni/thomas_fuchs.jpg" class="biopic" alt="Thomas Fuchs's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Thomas Fuchs (madrobby)</strong> is a Web and JavaScript guru from Vienna, Austria. He is the author of <a href="http://script.aculo.us/" title="read more about script.aculo.us">script.aculo.us</a>, a cross-browser JavaScript User Interface framework and he keeps busy as a core team member of the Prototype JavaScript framework, used by thousands of websites. He’s <a href="http://script.aculo.us/thomas" title="Thomas Fuchs's Website">available</a> for hire as a consultant for rich web user interfaces and JavaScript.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/alumni/tobi.jpg" class="biopic" alt="Tobias Lütke's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Tobias Lütke (xal)</strong> encountered Rails while struggling to find technology for his new company.
           Once found, he quickly ported the bits and pieces of his code over to Ruby which later became
@@ -112,8 +176,14 @@ subheader_3: "We thank you dearly for your service over the years."
           Over time, Tobi released many open source projects such as <a href="http://typo.leetsoft.com/" Title="Typo official site">Typo</a>, Hieraki,
           and <a href="http://www.liquidmarkup.org" title="Ruby library for rendering safe templates">Liquid</a>.
         </p>
-      </div><div class="section">
+        </div>
+      </div>
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/alumni/rick.png" class="biopic" alt="Rick Olson's Photo ">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Rick Olson (technoweenie)</strong> blames Ruby on Rails for
           destroying his ASP.Net career. He’s been using Rails actively since 2005 and is now working
@@ -121,4 +191,5 @@ subheader_3: "We thank you dearly for your service over the years."
           He’s also released several open source projects, such as Mephisto, Beast, along
           with <a href="https://github.com/technoweenie" title="Technoweenie's Github account">numerous plugins</a>.
         </p>
+        </div>
       </div>

--- a/core/index.html
+++ b/core/index.html
@@ -5,8 +5,12 @@ subheader_1: "These are the top producers that were given the keys to the"
 subheader_2: "source repository after months or even years of loyal service."
 subheader_3: "They are presented in order of acceptance to the team."
 ---
-      <div class="section">
+    <div class="container">
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/david.jpg" class="biopic" alt="David Heinemeier's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>David Heinemeier Hansson</strong> extracted Ruby on Rails from his
           work on <a href="http://www.basecamp.com" title="Basecamp: Project management app">Basecamp</a>. He released the
@@ -17,9 +21,14 @@ subheader_3: "They are presented in order of acceptance to the team."
           <a href="http://david.heinemeierhansson.com/" title="DHH's website">heinemeierhansson.com</a>,
           and you can follow him on Twitter <a href="http://twitter.com/dhh" title="follow @DHH on Twitter">@dhh</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/jeremy.jpg" class="biopic" alt="Jeremy Kemper's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Jeremy Kemper</strong> is a programmer at <a href="http://www.basecamp.com/" title="Basecamp: Project management app">Basecamp</a>
           hailing from <a href="http://maps.google.com/?q=Pasadena,+CA" title="Pasadena, California on Google maps">Pasadena, California</a>.
@@ -27,9 +36,14 @@ subheader_3: "They are presented in order of acceptance to the team."
           in pretty much all aspects of the framework and one of the top batters against new,
           incoming tickets. You can follow him on Twitter <a href="http://twitter.com/bitsweat" title="follow @bitsweat on Twitter">@bitsweat</a>
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/koz.jpg" class="biopic" alt="Michael Koziarski's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Michael Koziarski</strong> is a <a href="http://www.koziarski.com" title="Michael Koziarski's website">software consultant</a>
           based in Wellington, New Zealand. After a successful stint as an enterprise Java
@@ -37,9 +51,14 @@ subheader_3: "They are presented in order of acceptance to the team."
           contributor to <a href="http://www.therailsway.com/" title="The best practices in Rails application design">The Rails Way</a> and
           maintains a <a href="http://www.koziarski.net/" title="Michael Koziarski's blog">personal blog</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/jose.png" class="biopic" alt="José Valim's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>José Valim</strong> is the lead-developer and co-founder of <a href="http://plataformatec.com/" title="Projects Inception, Design and Software Development">Plataformatec</a>.
           He started working with Rails in late 2006 and began contributing actively after
@@ -48,9 +67,14 @@ subheader_3: "They are presented in order of acceptance to the team."
           <a href="http://github.com/josevalim" title="Jose Valim's Github account">open-source projects</a> to life. Check for
           yourself what he’s up to on <a href="http://blog.plataformatec.com.br/" title="Projects Inception, Design and Software Development">his company’s blog</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/santiago.jpg" class="biopic" alt="Santiago Pastorino's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Santiago Pastorino</strong> is the co-founder &amp; CTO of
           <a href="http://wyeworks.com/" title="We're software artisans, our solutions are carefully crafted by a team of development experts">WyeWorks</a>. He started
@@ -59,9 +83,14 @@ subheader_3: "They are presented in order of acceptance to the team."
           <a href="http://wyeworks.com/blog/" title="wyeworks's blog">his company’s blog</a>. Follow him on Twitter at
           <a href="http://twitter.com/spastorino" title="follow @spastorino on Twitter">@spastorino</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/aaron.png" class="biopic" alt="Aaron Patterson's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           By day, <strong>Aaron Patterson (tenderlove)</strong> is a mild mannered programmer for
           <a href="http://www.redhat.com" title="Red Hat website">Red Hat</a> whose Ruby code
@@ -71,9 +100,14 @@ subheader_3: "They are presented in order of acceptance to the team."
           it was probably him. You can find him on <a href="http://twitter.com/tenderlove" title="follow @tenderlove on twitter">twitter</a>,
           or read <a href="http://tenderlovemaking.com" title="Aaron Patterson's blog">his blog</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/xavier.png" class="biopic" alt="Xavier Noria's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Xavier Noria</strong> is an everlasting student and father of the most wonderful girl,
           as the picture to the left clearly demonstrates QED. An <a href="http://hashref.com/" title="Xavier Noria's website">independent
@@ -82,9 +116,14 @@ subheader_3: "They are presented in order of acceptance to the team."
           for years. Honored to have been presented a <a href="http://advogato.org/person/fxn/diary/532.html" title="entry blog about this experience">Ruby Hero Award</a>.
           Xavier is <a href="http://twitter.com/fxn" title="follow @fxn on twitter">@fxn</a> on Twitter.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/rafaelfranca.jpg" class="biopic" alt="Rafael França's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Rafael França</strong> is a member of <a href="http://plataformatec.com.br" title="Projects Inception, Design and Software Development">Plataformatec</a>'s
           development team. He has worked full time with Rails since 2010 and has been contributing
@@ -95,27 +134,42 @@ subheader_3: "They are presented in order of acceptance to the team."
           on <a href="http://github.com/rafaelfranca" title="Rafael Franca's Github account">Github</a>, or
           <a href="http://blog.plataformatec.com.br/" title="Plataformatec's blog">read Plataformatec’s blog</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/andrew-white.jpg" class="biopic" alt="Andrew White's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Andrew White</strong> is the CTO of <a href="http://www.unboxedconsulting.com/" title="Design and build digital products in Ruby on Rails using Lean and Agile techniques">Unboxed Consulting</a>,
           London’s premier Ruby on Rails development team and specialists in Agile &amp; Lean Startup techniques. He has
           been contributing to Rails since 2007 and has been producing open source software since 1997. You can follow
           him on <a href="https://twitter.com/pixeltrix" title="follow to @pixeltrix on twitter">Twitter</a> and <a href="https://github.com/pixeltrix" title="Pixeltrix's Github page">GitHub</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/guillermo-iguaran.jpg" class="biopic" alt="Guillermo Iguaran's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Guillermo Iguaran</strong> began using Ruby in 2008 and has been working
           with Rails since 2009. He started contributing to Rails framework and open-source
           world in 2011. Guillermo is from Colombia and right now he’s working as Software Engineer at <a href="http://ride.com" title="Pairing up co-workers to share the cost of their commutes">Ride</a>,
           and completing his Computer Sciences master’s degree. You can follow him on <a href="https://twitter.com/guilleiguaran" title="follow to @guilleiguaran on twitter">Twitter</a> or
           <a href="https://github.com/guilleiguaran" title="Guilleiguaran's Github account">Github</a>.
-      </div>
-      <div class="section">
+          </div>
+        </div>
+
+        <div class="section row">
+          <div class="col-sm-4">
         <img src="/images/pages/core/carlos-antonio.jpg" class="biopic" alt="Carlos Antonio's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Carlos Antonio</strong> is a software developer at <a href="https://www.enjoei.com.br" title="enjoei - a loja mais abusada da internê">enjoei</a>,
           working on a wide variety of projects and maintaining Open Source libraries like
@@ -125,18 +179,28 @@ subheader_3: "They are presented in order of acceptance to the team."
           an Open Source lover, contributing to many different projects. His motto is <em>Hacking Beautiful Code</em>.
           You can <a href="http://twitter.com/cantoniodasilva" title="follow to @cantoniodasilva on twitter"> follow him on Twitter</a>,
           <a href="https://github.com/carlosantoniodasilva" title="Carlos Antonio's Github account">check his Github</a>.</p>
-      </div>
-      <div class="section">
+          </div>
+        </div>
+
+        <div class="section row">
+          <div class="col-sm-4">
         <img src="/images/pages/core/senny.png" class="biopic" alt="Yves Senn's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Yves Senn</strong> is a software developer at <a href="https://www.4teamwork.ch">4teamwork</a> from Bern, Switzerland.
           Working with Java he started experimenting with Rails in 2008 and began contributing in 2012.
           He loves to hack on Open Source projects and is organizing <a href="http://ruvetia.org/">local meetups</a>.
           Yves is <a href="https://github.com/senny">@senny</a> on GitHub and you can follow him on <a href="https://twitter.com/yves_senn">Twitter</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <img src="/images/pages/core/godfrey.jpg" class="biopic" alt="Godfrey Chan's photo">
+        </div>
+        <div class="col-sm-8">
         <p>
           <strong>Godfrey Chan</strong> is part of the founding team at <a href="http://brewhouse.io/">Brewhouse Software</a>
           based in the beautiful British Columbia, <a href="https://github.com/vanruby/canada">Canada</a>. He began contributing
@@ -145,9 +209,13 @@ subheader_3: "They are presented in order of acceptance to the team."
           and sending <a href="http://rails-weekly.goodbits.io/">newsletters</a>. You can follow him on
           <a href="https://twitter.com/chancancode">Twitter</a> or <a href="https://github.com/chancancode">Github</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-8 col-sm-offset-4">
         <p>
           <em>Rails core members who are no longer active in the day-to-day stuff have been immortalized as <a href="/core/alumni/" title="Core alumni page">core alumni</a></em>.
         </p>
+        </div>
       </div>

--- a/deploy/index.html
+++ b/deploy/index.html
@@ -5,37 +5,62 @@ subheader_1: "Taking your Rails application live has never been easier."
 subheader_2: "Thanks to the rise of Passenger aka mod_rails,"
 subheader_3: "launching is now almost as easy as developing."
 ---
-      <div class="section">
-        <h2>Passenger<br>aka mod_rails</h2>
+    <div class="container">
+      <div class="section row">
+      <div class="col-sm-4">
+        <h2>Passenger<br class="hidden-xs" /> aka mod_rails</h2>
+        </div>
+        <div class="col-sm-8">
         <p>
           <img src="/images/pages/deploy/passenger.png" width="197" height="68" class="align-right" alt="Passenger">
           The easiest deployment setup for Rails is <a href="http://www.modrails.com/" title="Phusion Passenger website">Phusion Passenger</a> aka mod_rails. It’s a module for <a href="http://nginx.org" title="nginx news">nginx</a> and <a href="http://httpd.apache.org/" title="Apache HTTP Server Project">Apache</a> that automatically manages the back end. Just setup, launch, and enjoy.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <h2>Proxy setups</h2>
+        </div>
+        <div class="col-sm-8">
         <p>
           <img src="/images/pages/deploy/mongrel.jpg" width="182" height="82" class="align-right" alt="Mongrel">
           If you need more fine-grained control over your deployment setup, the common option is to use a front-end server like nginx and Apache combined with a proxy relay like <a href="http://haproxy.1wt.eu" title="HAproxy: The Reliable, High Performance TCP/HTTP Load Balancer">HAProxy</a> to cluster of <a href="http://unicorn.bogomips.org/" title="Unicorn: Rack HTTP server for fast clients and Unix">Unicorns</a>. That’s how Basecamp and a lot of other high-end deployments run.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <h2>JRuby on Rails</h2>
+        </div>
+        <div class="col-sm-8">
         <p>
           <img src="/images/pages/deploy/duke.jpg" width="100" height="80" class="align-right" alt="Duke">
           <a href="http://jruby.codehaus.org/" title="The Ruby Programming Language on the JVM">JRuby</a> brings Rails to the Java Virtual Machine. This means that you can deploy Rails applications on app servers like <a href="https://glassfish.dev.java.net/" title="Java EE 7 Application server">Glassfish</a> or <a href="http://jetty-rails.rubyforge.org/" title=" Jetty Rails: Java Web server">Jetty</a>. You can use <a href="http://caldersphere.rubyforge.org/warbler/" title="Warbler gem">Warbler</a> to package your Rails application as a standard WAR. Great for slipping into the enterprise.
         </p>
+        </div>
       </div>
-      <div class="section">
-        <h2>Automate with<br>Capistrano</h2>
+
+      <div class="section row">
+        <div class="col-sm-4">
+        <h2>Automate with<br class="hidden-xs" /> Capistrano</h2>
+        </div>
+        <div class="col-sm-8">
         <p>
           <img src="/images/pages/deploy/capistrano.jpg" width="190" height="72" class="align-right" alt="capistrano">
           <a href="http://www.capistranorb.com/" title="A remote server automation and deployment tool">Capistrano</a> brings deployment automation to Rails whether you’re working with a single server or on a cluster of dozens. It was extracted from the Basecamp tool chain (like Rails) by <a href="/core/alumni" title="Retired members of the core team">core alumni</a> Jamis Buck.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <h2 class="small">Hosting</h2>
+        </div>
+        <div class="col-sm-8">
         <p class="small">
           While Rails hosting is now common place, there’s a handful of dedicated Rails hosting companies that have been around for a long time and supporting the community: <a href="http://www.heroku.com/" title="Heroku website">Heroku</a>, <a href="http://railsmachine.com/" title="Rails Machine website">Rails Machine</a>, <a href="http://www.brightbox.co.uk/" title=" Btightbox website">Brightbox</a>, and <a href="http://www.engineyard.com/" title="Engine Yard Website">Engine Yard</a>. If you’re just looking for a VPS, we recommend <a href="http://www.rackspace.com" title="Rackspace website">Rackspace</a> (who gracefully donated slices for us to run Rails infrastructure on) or <a href="http://www.linode.com/" title="Linode website">Linode</a>.
         </p>
+        </div>
       </div>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -5,21 +5,35 @@ subheader_1: "We have everything you need to become an expert with Rails,"
 subheader_2: "including books, tutorials, manuals, and lots of"
 subheader_3: "open-source examples."
 ---
-      <div class="section">
+    <div class="container">
+      <div class="section row">
+      <div class="col-sm-4">
         <h2>Guides</h2>
+        </div>
+        <div class="col-sm-8">
         <p>
           If you’re just getting started or want to learn about Rails in general, check
           the <a href="http://guides.rubyonrails.org/" title=" Ruby on Rails Guides">Rails Guides</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <h2>APIs</h2>
+        </div>
+        <div class="col-sm-8">
         <p>
           <a href="http://api.rubyonrails.org/" title="Rails API">Browse all frameworks, classes, and methods</a>
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <h2>Books</h2>
+        </div>
+        <div class="col-sm-8">
         <p>
           <a href="http://pragprog.com/titles/rails4/agile-web-development-with-rails" title="Agile Web
           Development with Rails 4 ebook and paper book ">Agile Web
@@ -27,7 +41,7 @@ subheader_3: "open-source examples."
           killer web applications. For more advanced material, Rails core member José Valim has written
           <a href="http://pragprog.com/book/jvrails2/crafting-rails-applications" title="Crafting Rails 4 Applications ebook and paper book ">Crafting Rails 4 Applications</a>.
         </p>
-        <p class="centered">
+        <p class="text-center">
           <a href="http://pragprog.com/titles/rails4/agile-web-development-with-rails" class="nohover align-center" title="Agile Web
           Development with Rails 4 ebook and paper book "><img src="/images/pages/documentation/awdr4.png" class="bordered" width="144" height="153" alt="Agile web development with rails book"></a>
           <a href="http://pragprog.com/book/jvrails/crafting-rails-applications" class="nohover" title="Crafting Rails 4 Applications ebook and paper book"><img src="/images/pages/documentation/cra-mini.png" class="bordered" width="144" height="153" alt="Crafting rails applications book"></a>
@@ -35,13 +49,19 @@ subheader_3: "open-source examples."
         <p>
           See all the other <a href="http://www.amazon.com/gp/search?ie=UTF8&amp;keywords=ruby%20on%20rails&amp;tag=rubonrai-20&amp;index=books&amp;linkCode=ur2&amp;camp=1789&amp;creative=9325" title=" Related Searches about ruby on rails">Ruby on Rails books</a> at Amazon.
         </p>
+        </div>
       </div>
-      <div class="section">
-        <h2>Talking<br>foxes?</h2>
+
+      <div class="section row">
+        <div class="col-sm-4">
+        <h2>Talking<br class="hidden-xs" /> foxes?</h2>
+        </div>
+        <div class="col-sm-8">
         <p>
           <a href="http://media.rubyonrails.org/videos/rails_take2_with_sound.mov" class="nohover align-right" title="video about rails"><img src="/images/pages/documentation/chunkybacon.gif" class="bordered" alt="Chunky bacon"></a>
           <a href="http://mislav.uniqpath.com/poignant-guide/" title="Programming guide about ruby">why’s (poignant) guide to Ruby</a>
           is unlike any other guide to programming you have ever read. It features talking foxes,
           bizarre sidebars, and more crazy humor than most people can handle without loud chuckles.
         </p>
+        </div>
       </div>

--- a/download/index.html
+++ b/download/index.html
@@ -5,8 +5,12 @@ subheader_1: "Rails is low on dependencies and prides itself on shipping with"
 subheader_2: "most everything you need in the box. To get started, just install"
 subheader_3: "Ruby, the language, and RubyGems, the package manager."
 ---
-      <div class="section">
+    <div class="container">
+      <div class="section row">
+      <div class="col-sm-4">
         <h2>Ruby</h2>
+        </div>
+        <div class="col-sm-8">
         <p>
           <img src="/images/pages/download/ruby.png" class="align-right" alt="Ruby">
           We recommend <span class="highlight">Ruby 2.2</span> or newer for use with Rails.
@@ -20,9 +24,14 @@ subheader_3: "Ruby, the language, and RubyGems, the package manager."
         <p>
           We recommend managing your Ruby installation through <a href="https://github.com/sstephenson/rbenv" title="Rbenv repository on github">rbenv</a>. It’s an easy way to run multiple versions for different applications and update when a new release is made.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <h2>Rails</h2>
+        </div>
+        <div class="col-sm-8">
         <p>
           With Ruby installed, you can install all of Rails and its dependencies through RubyGems on the command line:
         </p>
@@ -30,9 +39,14 @@ subheader_3: "Ruby, the language, and RubyGems, the package manager."
         <p>
           New versions of Rails can be installed the same way.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <h2>Make your application</h2>
+        </div>
+        <div class="col-sm-8">
         <p>
           Create your application skeleton and start the server:
         </p>
@@ -42,12 +56,18 @@ rails server</pre></code>
         <p>
           You’re running Ruby on Rails! Follow the instructions on http://localhost:3000.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <h2 class="small">Editors</h2>
+        </div>
+        <div class="col-sm-8">
         <p class="small">
           <a href="http://macromates.com/" title="Macromates website">TextMate on OS X</a> has long been the favored Rails editor, but the classic editors are still going strong.
           <a href="http://www.vim.org/scripts/script.php?script_id=1567" title="Read more about VIM for rails">See VIM for Rails</a> and <a href="http://rinari.rubyforge.org/" title="Get Emacs for rails">Emacs for Rails</a>.
           For a full-on IDE, check out <a href="http://www.jetbrains.com/ruby/index.html" title="Ruby on rails IDE">JetBrains RubyMine</a>.
         </p>
+        </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -120,34 +120,46 @@ subheader_3: "write beautiful code by favoring convention over configuration."
           }, 15000);
         });
       </script>
-      <div id="used_by" class="section">
-        <h2>Who is already<br>on Rails?</h2>
+    <div class="container">
+      <div class="section row">
+      <div class="col-sm-4">
+        <h2>Who is already<br class="hidden-xs" /> on Rails?</h2>
+      </div>
+      <div class="col-sm-8">
         <p>Tens of thousands of Rails applications are already live. People are using Rails in the tiniest part-time operations to the biggest companies.</p>
-        <ul>
-          <li>
+        <div class="container-fluid text-center" id="used_by">
+        <div class="row">
+          <div class="col-sm-6">
             <a href="http://www.basecamp.com/?source=rails" title="Basecamp: Project management app"><img width="179" height="114" src="/images/applications/bcx.gif" alt="Image showing Basecamp's index page" class="bordered"></a>
             <p><a href="http://www.basecamp.com/?source=rails" title="Basecamp: Project management app">Basecamp</a>: The original Rails app.</p>
-          </li>
-          <li>
+          </div>
+          <div class="col-sm-6">
             <a href="http://twitter.com/" title="Twitter website"><img width="179" height="114" src="/images/applications/twitter.jpg" alt="Image showing Twitter's index page" class="bordered"></a>
             <p><a href="http://twitter.com/" title="Twitter website">Twitter</a>: Stay connected.</p>
-          </li>
-          <li>
+          </div>
+          <div class="col-sm-6">
             <a href="http://github.com/" title="Github build software better, together"><img width="179" height="114" src="/images/applications/github.jpg" alt="Image showing GitHub's index page" class="bordered"></a>
             <p><a href="http://github.com/" title="Github build software better, together">GitHub</a>: Git repo hosting.</p>
-          </li>
-          <li>
+          </div>
+          <div class="col-sm-6">
             <a href="http://www.shopify.com/" title="Shopify: e-commerce platform"><img width="179" height="114" src="/images/applications/shopify.jpg" alt="Shopify" class="bordered"></a>
             <p><a href="http://www.shopify.com/" title="Shopify: e-commerce platform">Shopify</a>: E-commerce made easy.</p>
-          </li>
-        </ul>
+          </div>
+        </div>
+        </div>
       </div>
-      <div class="section">
-        <h2>Who is<br>behind it?</h2>
+      </div>
+
+      <div class="section row">
+      <div class="col-sm-4">
+        <h2>Who is<br class="hidden-xs" /> behind it?</h2>
+      </div>
+      <div class="col-sm-8">
         <p>
           Rails was created in 2003 by <a href="http://david.heinemeierhansson.com/" title="DHH's website">David Heinemeier Hansson</a>
           and has since been extended by the <a href="/core">Rails core team</a> and
           <a href="http://contributors.rubyonrails.org" title="Access to the list of contributors">more than 3,700 contributors</a>.
         </p>
+      </div>
       </div>
     </div>

--- a/quotes/index.html
+++ b/quotes/index.html
@@ -7,58 +7,58 @@ subheader_3: "and/or funny people saying nice things about Rails."
 ---
       <blockquote>
         <p>
-          “Rails is the most well thought-out web development framework I’ve ever used.<br>
-          And that’s in a decade of doing web applications for a living. I’ve built my<br>
-          own frameworks, helped develop the Servlet API, and have created more than<br>
+          “Rails is the most well thought-out web development framework I’ve ever used.<br class="hidden-xs" />
+          And that’s in a decade of doing web applications for a living. I’ve built my<br class="hidden-xs" />
+          own frameworks, helped develop the Servlet API, and have created more than<br class="hidden-xs" />
           a few web servers from scratch. Nobody has done it like this before.”
         </p>
         <p><cite>– James Duncan Davidson, Creator of Tomcat and Ant</cite></p>
       </blockquote>
       <blockquote>
         <p>
-          “Ruby on Rails is a breakthrough in lowering the barriers of entry to programming.<br>
-          Powerful web applications that formerly might have taken weeks or months<br>
+          “Ruby on Rails is a breakthrough in lowering the barriers of entry to programming.<br class="hidden-xs" />
+          Powerful web applications that formerly might have taken weeks or months<br class="hidden-xs" />
           to develop can be produced in a matter of days.”
         </p>
         <p><cite>– Tim O’Reilly, Founder of O’Reilly Media</cite></p>
       </blockquote>
       <blockquote>
         <p>
-          “It is impossible not to notice Ruby on Rails.  It has had a huge effect both in<br>
-          and outside the Ruby community... Rails has become a standard to which even<br>
+          “It is impossible not to notice Ruby on Rails.  It has had a huge effect both in<br class="hidden-xs" />
+          and outside the Ruby community... Rails has become a standard to which even<br class="hidden-xs" />
           well-established tools are comparing themselves to.”
         </p>
         <p><cite>– Martin Fowler, Author of Refactoring, PoEAA, XP Explained</cite></p>
       </blockquote>
       <blockquote>
         <p>
-          “What sets this framework apart from all of the others is the preference for<br>
-          convention over configuration making applications easier<br>
+          “What sets this framework apart from all of the others is the preference for<br class="hidden-xs" />
+          convention over configuration making applications easier<br class="hidden-xs" />
           to develop and understand.”
         </p>
         <p><cite>– Sam Ruby, ASF board of directors</cite></p>
       </blockquote>
       <blockquote>
         <p>
-          “Before Ruby on Rails, web programming required a lot of verbiage, steps and time.<br>
-          Now, web designers and software engineers can develop a website<br>
-          much faster and more simply, enabling them to be more productive<br>
+          “Before Ruby on Rails, web programming required a lot of verbiage, steps and time.<br class="hidden-xs" />
+          Now, web designers and software engineers can develop a website<br class="hidden-xs" />
+          much faster and more simply, enabling them to be more productive<br class="hidden-xs" />
           and effective in their work.”
         </p>
         <p><cite>– Bruce Perens, Open Source Luminary</cite></p>
       </blockquote>
       <blockquote>
         <p>
-          “After researching the market, Ruby on Rails stood out as the best choice.<br>
-          We have been very happy with that decision.  We will continue<br>
+          “After researching the market, Ruby on Rails stood out as the best choice.<br class="hidden-xs" />
+          We have been very happy with that decision.  We will continue<br class="hidden-xs" />
           building on Rails and consider it a key business advantage.”
         </p>
         <p><cite>– Evan Williams, Creator of Blogger and ODEO</cite></p>
       </blockquote>
       <blockquote>
         <p>
-          “Ruby on Rails is astounding. Using it is like watching a kung-fu movie,<br>
-          where a dozen bad-ass frameworks prepare to beat up the little newcomer<br>
+          “Ruby on Rails is astounding. Using it is like watching a kung-fu movie,<br class="hidden-xs" />
+          where a dozen bad-ass frameworks prepare to beat up the little newcomer<br class="hidden-xs" />
           only to be handed their asses in a variety of imaginative ways.”
         </p>
         <p><cite>– Nathan Torkington, O’Reilly Program Chair for OSCON</cite></p>

--- a/screencasts/index.html
+++ b/screencasts/index.html
@@ -5,10 +5,14 @@ subheader_1: "Lean back and enjoy the shows, but be careful: Going back to your"
 subheader_2: "former treadmill after being exposed to these movies can prove"
 subheader_3: "exceedingly painful. Don’t say we didn’t try to warn you."
 ---
-      <div class="section">
+    <div class="container">
+      <div class="section row">
+      <div class="col-sm-4">
         <a href="http://railsforzombies.org" class="screencast" title="Code school about Rails">
-          <img width="198" height="158" src="/images/pages/screencasts/Rails_for_Zombies-2.jpg" alt="Rails for zombies">
+          <img src="/images/pages/screencasts/Rails_for_Zombies-2.jpg" alt="Rails for zombies">
         </a>
+        </div>
+        <div class="col-sm-8">
         <h3>Learning Rails the Zombie Way</h3>
         <p>
           If you’re new to Rails and want to give it a try, then head over to
@@ -22,11 +26,16 @@ subheader_3: "exceedingly painful. Don’t say we didn’t try to warn you."
           Rails 2</a>, <a href="http://media.rubyonrails.org/video/rails-0-5.mov" title="Video about history of rails 0.5">Ruby on
           Rails 0.5</a> and for <a href="http://media.rubyonrails.org/video/rails_take2_with_sound.mov" title="Video about history of rails 1.0">Ruby on Rails 1.0</a>.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <a href="http://rails4.codeschool.com/videos" class="screencast" title="Rails 4 videos">
-          <img width="198" height="158" src="/images/pages/screencasts/rails4_zombie_outlaws.jpg" alt="Rails 4 zombie outlaws">
+          <img src="/images/pages/screencasts/rails4_zombie_outlaws.jpg" alt="Rails 4 zombie outlaws">
         </a>
+        </div>
+        <div class="col-sm-8">
         <h3>Rails 4: Zombie Outlaws</h3>
         <p>
           If you’re looking to get your hands dirty with the newest version of Rails, the
@@ -38,11 +47,16 @@ subheader_3: "exceedingly painful. Don’t say we didn’t try to warn you."
           Also checkout the <a href="http://ruby5.envylabs.com" title="Ruby Podcast">Ruby5
           Podcast</a> for keeping up to date with the latest libraries and news from the Rails world.
         </p>
+        </div>
       </div>
-      <div class="section">
+
+      <div class="section row">
+        <div class="col-sm-4">
         <a href="http://railscasts.com" class="screencast" title="Click to access to Rails Casts">
-          <img width="198" height="158" src="/images/pages/screencasts/railscasts.png" alt="Rails casts">
+          <img src="/images/pages/screencasts/railscasts.png" alt="Rails casts">
         </a>
+        </div>
+        <div class="col-sm-8">
         <h3>More free screencasts from Railscasts.com</h3>
         <p>
           If the screencast above got you interested in learning more by video, you can
@@ -50,4 +64,5 @@ subheader_3: "exceedingly painful. Don’t say we didn’t try to warn you."
           It’s all about short, sweet videos that show you how to use various features of Rails
           and they’re done by the same fantastic Ryan Bates that did the video above.
         </p>
+        </div>
       </div>

--- a/security/index.html
+++ b/security/index.html
@@ -5,8 +5,12 @@ subheader_1: "Rails takes web security very seriously."
 subheader_2: "If you found a vulnerability in Ruby on Rails, follow"
 subheader_3: "these steps to safely report the issue to the core team."
 ---
-      <div class="section">
+    <div class="container">
+      <div class="section row">
+      <div class="col-sm-4">
       <h2>Supported versions</h2>
+      </div>
+      <div class="col-sm-8">
     	<p>
         Support of the Rails framework is divided into four groups: New features, bug fixes,
         security issues, and severe security issues. They are handled as follows:
@@ -59,8 +63,14 @@ subheader_3: "these steps to safely report the issue to the core team."
         released. If you are not comfortable maintaining your own versions, you
         should upgrade to a supported version.
       </p>
+      </div>
+    </div>
 
+    <div class="section row">
+      <div class="col-sm-4">
     	<h2>Reporting a bug</h2>
+      </div>
+      <div class="col-sm-8">
     	<p>
         All security bugs in rails should be reported through our
         <a href="https://hackerone.com/rails">bounty program page at HackerOne</a>. This will
@@ -94,8 +104,14 @@ subheader_3: "these steps to safely report the issue to the core team."
         to that address please do not discuss your issue, simply say that you’re trying to get
         a hold of someone from the security team.
       </p>
+      </div>
+    </div>
 
+    <div class="section row">
+      <div class="col-sm-4">
     	<h2>Disclosure Policy</h2>
+      </div>
+      <div class="col-sm-8">
     	<p>Ruby on Rails has a 5 step disclosure policy.</p>
 
     	<ol>
@@ -139,8 +155,14 @@ subheader_3: "these steps to safely report the issue to the core team."
         as timely a manner as possible, however it’s important that we follow the release
         process above to ensure that the disclosure is handled in a consistent manner.
       </p>
+      </div>
+    </div>
 
+    <div class="section row">
+      <div class="col-sm-4">
     	<h2>Receiving Security Updates</h2>
+      </div>
+      <div class="col-sm-8">
     	<p>
         The best way to receive all the security announcements is to subscribe to the
         <a href="http://groups.google.com/group/rubyonrails-security">rails security
@@ -156,10 +178,17 @@ subheader_3: "these steps to safely report the issue to the core team."
         this policy for high traffic or important sites, as any disclosure beyond the
         minimum required to coordinate a fix could cause an early leak of the vulnerability.
       </p>
+      </div>
+    </div>
 
+    <div class="section row">
+      <div class="col-sm-4">
     	<h2>Comments on this Policy</h2>
+      </div>
+      <div class="col-sm-8">
     	<p>
         If you have any suggestions to improve this policy, please send an email to
         <a href="mailto:security@rubyonrails.org">security@rubyonrails.org</a>.
       </p>
       </div>
+    </div>

--- a/styles.css
+++ b/styles.css
@@ -46,82 +46,73 @@ img.align-right {
 span.highlight {
 	background-color: #ffc;
 }
-div.section {
-	margin: 0px auto;
-	overflow: hidden;
-	width: 700px;
-}
 div.section h2 {
-	color: #000;
-	float: left;
 	font-family: Georgia;
 	font-size: 28px;
+
 	font-weight: normal;
 	line-height: 120%;
-	margin: 0px 0px 20px 0px;
-	text-align: right;
-	width: 200px;
+  margin: 0 10px 20px 0;
+}
+@media (min-width:768px) {
+  section h2.small { font-size: 20px; }
+}
+@media (max-width:768px) {
+  section h2 { text-align: center; }
 }
 div.section h3 {
 	color: #900;
 	font-family: Georgia;
 	font-size: 18px;
-	margin: 0px 0px 0px 250px;
+  margin: 0 10px 0px 10px;
 	line-height: 140%;
+}
+div.section ul, div.section ol {
+  margin: 0 10px 14px 10px;
 }
 div.section p {
   font-family: Georgia;
   font-size: 18px;
   line-height: 140%;
-  margin: 0px 0px 25px 250px;
-  width: 450px;
+  margin: 0 10px 25px 10px;
 }
-div.section h2.small {
-	font-size: 20px;
-}
+@media (min-width: 768px) {
 div.section p.small {
 	font-size: 14px;
 }
-pre {
-	margin: 0px 0px 25px 250px;
-	width: 450px;
 }
-pre code {
-	line-height: 140%;
-	margin: 0px 25px;
-	width: auto;
-	display: block;
+div.section pre {
+  margin: 0 10px 25px 10px;
 }
-div.section p.more {
-	font-size: 12px;
-	text-align: center;
+@media (min-width: 768px) {
+  div.section pre { margin-left: 35px;}
 }
-div.section p.centered {
-	text-align: center;
-}
+
+@media (min-width: 768px) {
 div.section p.footnote {
 	font-size: 12px;
+}
 }
 div.section img.biopic {
 	background-color: #fff;
 	border: 2px solid #ccc;
 	padding: 2px;
-	float: left;
-	width: 158px;
-	height: 180px;
-	margin: 0px 0px 10px 40px;
+  margin-top: 0; margin-bottom: 6px;
+  width: 158px;
+  height: 180px;
+  margin-right: 12px; margin-left: 35px;
 }
+
 div.section a.screencast {
-	background-color: transparent !important;
-	float: left;
-	clear: left;
-	margin: 0px 0px 25px 25px;
+  margin: 0;
 }
 div.section a.screencast img {
-	display: block;
 	background-color: #fff;
 	border: 2px solid #ccc;
 	padding: 2px;
+  width: 198px;
+  height: 158px;
+  margin-right: 12px; margin-left: 35px;
 }
 div.section code {
 	font-family: Courier New, Courier, mono;
@@ -148,9 +139,6 @@ div.section code {
 	font-size: 28px;
 	font-weight: normal;
 	line-height: 120%;
-	margin: 0px auto;
-	text-align: center;
-	width: 700px;
 }
 #sponsored_by {
 	margin: 17px 0px !important;
@@ -162,26 +150,9 @@ div.section code {
 	vertical-align: -7px;
 }
 
-#used_by ul {
-	list-style: none;
-	margin: 0px 0px 0px 280px;
-	padding: 0px;
-	overflow: hidden;
-}
-#used_by ul li {
-	float: left;
-	margin: 0px 0px 20px 0px;
-	width: 209px;
-}
-#used_by ul li img {
-	display: block;
-	margin: 0px 0px 5px 0px;
-}
-#used_by ul li p {
+#used_by p {
 	font-size: 10px;
 	font-family: inherit;
-	margin: 0px;
-	width: auto;
 }
 
 /* Quotes */
@@ -226,11 +197,16 @@ footer a:focus, footer a:hover                      {text-decoration: none}
 footer                                              {text-align: center}
 #announce                                           {font-size: 11px; line-height: 13px}
 #slivers p                                          {font-size: 10px}
-h1                                                  {font-size: 31px; line-height: 30px; font-weight: 700}
-header h2                                           {font-size: 18px; line-height: 24px; font-weight: 400}
-@media (min-width: 768px) {
-  h1                                                {font-size: 38px}
-  header h2                                         {font-size: 21px}
+h1                                                  {font-size: 38px; line-height: 30px; font-weight: 700}
+header h2                                           {font-size: 21px; line-height: 24px; font-weight: 400}
+@media (max-width: 768px) {
+  h1                                                {font-size: 31px}
+  header h2                                         {font-size: 18px}
+}
+
+.col-sm-4                                           {text-align: right}
+@media (max-width: 768px) {
+  .col-sm-4, h3                                         {text-align: center}
 }
 
 /* COLOR AND BACKGROUND */


### PR DESCRIPTION
Make every page responsive by turning the central two-column sections from fixed width to a grid system that adapts at smaller screen sizes.

Once again, the site will look the same in a normal-sized window, but will adapt nicely (and not overflow) at smaller resolutions.

---

Note: this is the second-to-last step! After this, the next PR will change the viewport to show the responsive design on iPhone/iPad etc, and optimize the CSS file to remove all the unused selectors etc.

In the comments, I'm attaching screenshots of all the pages after this PR taken on Safari (Mac). The next PR will be the one with screenshots taken from various iOS devices :grinning: 