### PR TITLE
Make rubyonrails.org responsive

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,5 +6,5 @@ subheader_2: "programmer happiness and sustainable productivity. It lets you wri
 subheader_3: "beautiful code by favoring convention over configuration."
 ---
     <div class="container-fluid text-center">
-      <p class="missing">Sorry! We couldn’t find what you were looking for.</p>
+      <h2>Sorry! We couldn’t find what you were looking for.</h2>
     </div>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -4,7 +4,7 @@
       <a class="navbar-brand" href="/" title="Ruby on Rails Main">
         <img alt="Brand" src="/images/rails.png">
       </a>
-      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-collapse">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#menu">
         <span class="sr-only">Toggle navigation</span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
@@ -12,7 +12,7 @@
       </button>
     </div>
 
-    <div class="collapse navbar-collapse" id="bs-collapse">
+    <div class="collapse navbar-collapse" id="menu">
       <ul class="nav navbar-nav">
         <li><a href="/" title="Ruby on Rails Main">Overview</a></li>
         <li><a href="/download/" title="Download the Ruby on Rails latest stable version">Download</a></li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
   <head>
     <title>Ruby on Rails{% if page.title %}: {{ page.title }}{% endif %}</title>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=800">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" media="screen" rel="stylesheet" type="text/css" />
     <link href="/styles.css" type="text/css" media="screen" rel="stylesheet">
@@ -15,19 +15,17 @@
   </head>
   <body>
 {% include navigation.html %}
-    <div role="main"><section>
-      <div id="article"><article>
+      <article>
         <header class="container text-center">
           <h1>{{ page.header }}</h1>
-          <h2>
+          <h4>
             {{ page.subheader_1 }}<br class="hidden-xs" />
             {{ page.subheader_2 }}<br class="hidden-xs" />
             {{ page.subheader_3 }}
-          </h2>
+          </h4>
         </header>
         {{ content }}
-      </article></div>
-    </section></div>
+      </article>
 {% include footer.html %}
   </body>
 </html>

--- a/community/index.html
+++ b/community/index.html
@@ -6,14 +6,14 @@ subheader_2: "want to help others learn. Become a part of the family, learn from
 subheader_3: "others, and give something back when you can."
 ---
     <div class="container">
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <h2>Mailing lists</h2>
         </div>
         <div class="col-sm-8">
         <p>
           <a href="http://groups.google.com/group/rubyonrails-talk" title="Google group for Ruby on Rails users">Ruby on Rails Talk</a> is where
-          Rails users come to <span class="highlight">seek help, announce projects, and discuss</span>
+          Rails users come to <mark>seek help, announce projects, and discuss</mark>
           all kind of matters surrounding the framework and the community. If you’re working on a patch,
           you can raise issues on <a href="http://groups.google.com/group/rubyonrails-core" title="Google group Ruby on Rails: Core">the core list</a>.
           Finally, there’s the <a href="http://groups.google.com/group/rubyonrails-security" title="Security annoucements for Ruby on Rails">security
@@ -22,7 +22,7 @@ subheader_3: "others, and give something back when you can."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <h2>Twitter &amp; Blogs</h2>
         </div>
@@ -34,14 +34,14 @@ subheader_3: "others, and give something back when you can."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <h2>IRC</h2>
         </div>
         <div class="col-sm-8">
         <p>
-          Sometimes it’s just easier to get help or <span class="highlight">discuss matters
-          in real time</span>. The <em>#rubyonrails</em> channel on <em>irc.freenode.net</em>
+          Sometimes it’s just easier to get help or <mark>discuss matters
+          in real time</mark>. The <em>#rubyonrails</em> channel on <em>irc.freenode.net</em>
           allows for just that. Try <em>#rails-contrib</em> if you want help or discuss your
           patch to Rails itself.
         </p>

--- a/core/alumni/index.html
+++ b/core/alumni/index.html
@@ -6,7 +6,7 @@ subheader_2: "active in the day-to-day improvement of the framework."
 subheader_3: "We thank you dearly for your service over the years."
 ---
     <div class="container">
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/yehuda.jpg" class="biopic" alt="Yehuda Katz's photo">
         </div>
@@ -21,7 +21,7 @@ subheader_3: "We thank you dearly for your service over the years."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/jonleighton.jpg" alt="Jon Leighton's Photo" class="biopic">
         </div>
@@ -36,7 +36,7 @@ subheader_3: "We thank you dearly for your service over the years."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/pic1218916611.jpg" alt="Josh Peek's Photo" class="biopic">
         </div>
@@ -47,7 +47,7 @@ subheader_3: "We thank you dearly for your service over the years."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/carl.jpg" alt="Carl Lerche's Photo" class="biopic">
         </div>
@@ -58,7 +58,7 @@ subheader_3: "We thank you dearly for your service over the years."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/pratik.jpg" alt="Pratik Naik's Photo" class="biopic">
         </div>
@@ -70,7 +70,7 @@ subheader_3: "We thank you dearly for your service over the years."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/alumni/jamis.jpg" alt="Jamis Buck's Photo" class="biopic">
         </div>
@@ -86,7 +86,7 @@ subheader_3: "We thank you dearly for your service over the years."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/alumni/marcel_molina.jpg" class="biopic" alt="Marcel Molina Jr.'s photo">
         </div>
@@ -101,7 +101,7 @@ subheader_3: "We thank you dearly for your service over the years."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/alumni/nicholas.jpg" class="biopic" alt="Nicholas Seckar's Photo">
         </div>
@@ -115,7 +115,7 @@ subheader_3: "We thank you dearly for your service over the years."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/alumni/florian.jpg" class="biopic" alt="Florian Weber's photo">
         </div>
@@ -126,7 +126,7 @@ subheader_3: "We thank you dearly for your service over the years."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/alumni/sam.jpg" class="biopic" alt="Sam Stephenson's photo">
         </div>
@@ -139,7 +139,7 @@ subheader_3: "We thank you dearly for your service over the years."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/alumni/scott.jpg" class="biopic" alt="Scott Barron's page">
         </div>
@@ -152,7 +152,7 @@ subheader_3: "We thank you dearly for your service over the years."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/alumni/thomas_fuchs.jpg" class="biopic" alt="Thomas Fuchs's photo">
         </div>
@@ -163,7 +163,7 @@ subheader_3: "We thank you dearly for your service over the years."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/alumni/tobi.jpg" class="biopic" alt="Tobias Lütke's photo">
         </div>
@@ -179,7 +179,7 @@ subheader_3: "We thank you dearly for your service over the years."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/alumni/rick.png" class="biopic" alt="Rick Olson's Photo ">
         </div>

--- a/core/index.html
+++ b/core/index.html
@@ -6,7 +6,7 @@ subheader_2: "source repository after months or even years of loyal service."
 subheader_3: "They are presented in order of acceptance to the team."
 ---
     <div class="container">
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/david.jpg" class="biopic" alt="David Heinemeier's photo">
         </div>
@@ -24,7 +24,7 @@ subheader_3: "They are presented in order of acceptance to the team."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/jeremy.jpg" class="biopic" alt="Jeremy Kemper's photo">
         </div>
@@ -39,7 +39,7 @@ subheader_3: "They are presented in order of acceptance to the team."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/koz.jpg" class="biopic" alt="Michael Koziarski's photo">
         </div>
@@ -54,7 +54,7 @@ subheader_3: "They are presented in order of acceptance to the team."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/jose.png" class="biopic" alt="José Valim's photo">
         </div>
@@ -70,7 +70,7 @@ subheader_3: "They are presented in order of acceptance to the team."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/santiago.jpg" class="biopic" alt="Santiago Pastorino's photo">
         </div>
@@ -86,7 +86,7 @@ subheader_3: "They are presented in order of acceptance to the team."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/aaron.png" class="biopic" alt="Aaron Patterson's photo">
         </div>
@@ -103,7 +103,7 @@ subheader_3: "They are presented in order of acceptance to the team."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/xavier.png" class="biopic" alt="Xavier Noria's photo">
         </div>
@@ -119,7 +119,7 @@ subheader_3: "They are presented in order of acceptance to the team."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/rafaelfranca.jpg" class="biopic" alt="Rafael França's photo">
         </div>
@@ -137,7 +137,7 @@ subheader_3: "They are presented in order of acceptance to the team."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/andrew-white.jpg" class="biopic" alt="Andrew White's photo">
         </div>
@@ -151,7 +151,7 @@ subheader_3: "They are presented in order of acceptance to the team."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/guillermo-iguaran.jpg" class="biopic" alt="Guillermo Iguaran's photo">
         </div>
@@ -165,7 +165,7 @@ subheader_3: "They are presented in order of acceptance to the team."
           </div>
         </div>
 
-        <div class="section row">
+        <div class="row">
           <div class="col-sm-4">
         <img src="/images/pages/core/carlos-antonio.jpg" class="biopic" alt="Carlos Antonio's photo">
         </div>
@@ -182,7 +182,7 @@ subheader_3: "They are presented in order of acceptance to the team."
           </div>
         </div>
 
-        <div class="section row">
+        <div class="row">
           <div class="col-sm-4">
         <img src="/images/pages/core/senny.png" class="biopic" alt="Yves Senn's photo">
         </div>
@@ -196,7 +196,7 @@ subheader_3: "They are presented in order of acceptance to the team."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <img src="/images/pages/core/godfrey.jpg" class="biopic" alt="Godfrey Chan's photo">
         </div>
@@ -212,7 +212,7 @@ subheader_3: "They are presented in order of acceptance to the team."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-8 col-sm-offset-4">
         <p>
           <em>Rails core members who are no longer active in the day-to-day stuff have been immortalized as <a href="/core/alumni/" title="Core alumni page">core alumni</a></em>.

--- a/deploy/index.html
+++ b/deploy/index.html
@@ -6,60 +6,60 @@ subheader_2: "Thanks to the rise of Passenger aka mod_rails,"
 subheader_3: "launching is now almost as easy as developing."
 ---
     <div class="container">
-      <div class="section row">
+      <div class="row">
       <div class="col-sm-4">
         <h2>Passenger<br class="hidden-xs" /> aka mod_rails</h2>
         </div>
         <div class="col-sm-8">
         <p>
-          <img src="/images/pages/deploy/passenger.png" width="197" height="68" class="align-right" alt="Passenger">
+          <img src="/images/pages/deploy/passenger.png" width="197" height="68" class="pull-right" alt="Passenger">
           The easiest deployment setup for Rails is <a href="http://www.modrails.com/" title="Phusion Passenger website">Phusion Passenger</a> aka mod_rails. It’s a module for <a href="http://nginx.org" title="nginx news">nginx</a> and <a href="http://httpd.apache.org/" title="Apache HTTP Server Project">Apache</a> that automatically manages the back end. Just setup, launch, and enjoy.
         </p>
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <h2>Proxy setups</h2>
         </div>
         <div class="col-sm-8">
         <p>
-          <img src="/images/pages/deploy/mongrel.jpg" width="182" height="82" class="align-right" alt="Mongrel">
+          <img src="/images/pages/deploy/mongrel.jpg" width="182" height="82" class="pull-right" alt="Mongrel">
           If you need more fine-grained control over your deployment setup, the common option is to use a front-end server like nginx and Apache combined with a proxy relay like <a href="http://haproxy.1wt.eu" title="HAproxy: The Reliable, High Performance TCP/HTTP Load Balancer">HAProxy</a> to cluster of <a href="http://unicorn.bogomips.org/" title="Unicorn: Rack HTTP server for fast clients and Unix">Unicorns</a>. That’s how Basecamp and a lot of other high-end deployments run.
         </p>
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <h2>JRuby on Rails</h2>
         </div>
         <div class="col-sm-8">
         <p>
-          <img src="/images/pages/deploy/duke.jpg" width="100" height="80" class="align-right" alt="Duke">
+          <img src="/images/pages/deploy/duke.jpg" width="100" height="80" class="pull-right" alt="Duke">
           <a href="http://jruby.codehaus.org/" title="The Ruby Programming Language on the JVM">JRuby</a> brings Rails to the Java Virtual Machine. This means that you can deploy Rails applications on app servers like <a href="https://glassfish.dev.java.net/" title="Java EE 7 Application server">Glassfish</a> or <a href="http://jetty-rails.rubyforge.org/" title=" Jetty Rails: Java Web server">Jetty</a>. You can use <a href="http://caldersphere.rubyforge.org/warbler/" title="Warbler gem">Warbler</a> to package your Rails application as a standard WAR. Great for slipping into the enterprise.
         </p>
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <h2>Automate with<br class="hidden-xs" /> Capistrano</h2>
         </div>
         <div class="col-sm-8">
         <p>
-          <img src="/images/pages/deploy/capistrano.jpg" width="190" height="72" class="align-right" alt="capistrano">
+          <img src="/images/pages/deploy/capistrano.jpg" width="190" height="72" class="pull-right" alt="capistrano">
           <a href="http://www.capistranorb.com/" title="A remote server automation and deployment tool">Capistrano</a> brings deployment automation to Rails whether you’re working with a single server or on a cluster of dozens. It was extracted from the Basecamp tool chain (like Rails) by <a href="/core/alumni" title="Retired members of the core team">core alumni</a> Jamis Buck.
         </p>
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row small">
         <div class="col-sm-4">
-        <h2 class="small">Hosting</h2>
+        <h2>Hosting</h2>
         </div>
         <div class="col-sm-8">
-        <p class="small">
+        <p>
           While Rails hosting is now common place, there’s a handful of dedicated Rails hosting companies that have been around for a long time and supporting the community: <a href="http://www.heroku.com/" title="Heroku website">Heroku</a>, <a href="http://railsmachine.com/" title="Rails Machine website">Rails Machine</a>, <a href="http://www.brightbox.co.uk/" title=" Btightbox website">Brightbox</a>, and <a href="http://www.engineyard.com/" title="Engine Yard Website">Engine Yard</a>. If you’re just looking for a VPS, we recommend <a href="http://www.rackspace.com" title="Rackspace website">Rackspace</a> (who gracefully donated slices for us to run Rails infrastructure on) or <a href="http://www.linode.com/" title="Linode website">Linode</a>.
         </p>
         </div>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -6,7 +6,7 @@ subheader_2: "including books, tutorials, manuals, and lots of"
 subheader_3: "open-source examples."
 ---
     <div class="container">
-      <div class="section row">
+      <div class="row">
       <div class="col-sm-4">
         <h2>Guides</h2>
         </div>
@@ -18,7 +18,7 @@ subheader_3: "open-source examples."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <h2>APIs</h2>
         </div>
@@ -29,22 +29,22 @@ subheader_3: "open-source examples."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <h2>Books</h2>
         </div>
         <div class="col-sm-8">
         <p>
           <a href="http://pragprog.com/titles/rails4/agile-web-development-with-rails" title="Agile Web
-          Development with Rails 4 ebook and paper book ">Agile Web
+          Development with Rails 4 ebook and paper book">Agile Web
           Development with Rails</a> will teach you all you need to know about Ruby and Rails 4 to build
           killer web applications. For more advanced material, Rails core member José Valim has written
           <a href="http://pragprog.com/book/jvrails2/crafting-rails-applications" title="Crafting Rails 4 Applications ebook and paper book ">Crafting Rails 4 Applications</a>.
         </p>
         <p class="text-center">
-          <a href="http://pragprog.com/titles/rails4/agile-web-development-with-rails" class="nohover align-center" title="Agile Web
-          Development with Rails 4 ebook and paper book "><img src="/images/pages/documentation/awdr4.png" class="bordered" width="144" height="153" alt="Agile web development with rails book"></a>
-          <a href="http://pragprog.com/book/jvrails/crafting-rails-applications" class="nohover" title="Crafting Rails 4 Applications ebook and paper book"><img src="/images/pages/documentation/cra-mini.png" class="bordered" width="144" height="153" alt="Crafting rails applications book"></a>
+          <a href="http://pragprog.com/titles/rails4/agile-web-development-with-rails" class="framed" title="Agile Web
+          Development with Rails 4 ebook and paper book "><img src="/images/pages/documentation/awdr4.png" width="144" height="153" alt="Agile web development with rails book"></a>
+          <a href="http://pragprog.com/book/jvrails/crafting-rails-applications" class="framed" title="Crafting Rails 4 Applications ebook and paper book"><img src="/images/pages/documentation/cra-mini.png" width="144" height="153" alt="Crafting rails applications book"></a>
         </p>
         <p>
           See all the other <a href="http://www.amazon.com/gp/search?ie=UTF8&amp;keywords=ruby%20on%20rails&amp;tag=rubonrai-20&amp;index=books&amp;linkCode=ur2&amp;camp=1789&amp;creative=9325" title=" Related Searches about ruby on rails">Ruby on Rails books</a> at Amazon.
@@ -52,13 +52,13 @@ subheader_3: "open-source examples."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <h2>Talking<br class="hidden-xs" /> foxes?</h2>
         </div>
         <div class="col-sm-8">
         <p>
-          <a href="http://media.rubyonrails.org/videos/rails_take2_with_sound.mov" class="nohover align-right" title="video about rails"><img src="/images/pages/documentation/chunkybacon.gif" class="bordered" alt="Chunky bacon"></a>
+          <a href="http://media.rubyonrails.org/videos/rails_take2_with_sound.mov" class="pull-right framed" title="video about rails"><img src="/images/pages/documentation/chunkybacon.gif" alt="Chunky bacon"></a>
           <a href="http://mislav.uniqpath.com/poignant-guide/" title="Programming guide about ruby">why’s (poignant) guide to Ruby</a>
           is unlike any other guide to programming you have ever read. It features talking foxes,
           bizarre sidebars, and more crazy humor than most people can handle without loud chuckles.

--- a/download/index.html
+++ b/download/index.html
@@ -6,14 +6,14 @@ subheader_2: "most everything you need in the box. To get started, just install"
 subheader_3: "Ruby, the language, and RubyGems, the package manager."
 ---
     <div class="container">
-      <div class="section row">
+      <div class="row">
       <div class="col-sm-4">
         <h2>Ruby</h2>
         </div>
         <div class="col-sm-8">
         <p>
-          <img src="/images/pages/download/ruby.png" class="align-right" alt="Ruby">
-          We recommend <span class="highlight">Ruby 2.2</span> or newer for use with Rails.
+          <img src="/images/pages/download/ruby.png" class="pull-right" alt="Ruby">
+          We recommend <mark>Ruby 2.2</mark> or newer for use with Rails.
           Rails requires Ruby 1.9.3 or newer.
         </p>
         <p>
@@ -27,7 +27,7 @@ subheader_3: "Ruby, the language, and RubyGems, the package manager."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <h2>Rails</h2>
         </div>
@@ -42,7 +42,7 @@ subheader_3: "Ruby, the language, and RubyGems, the package manager."
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
         <div class="col-sm-4">
         <h2>Make your application</h2>
         </div>
@@ -59,12 +59,12 @@ rails server</pre></code>
         </div>
       </div>
 
-      <div class="section row">
+      <div class="row small">
         <div class="col-sm-4">
-        <h2 class="small">Editors</h2>
+        <h2>Editors</h2>
         </div>
         <div class="col-sm-8">
-        <p class="small">
+        <p>
           <a href="http://macromates.com/" title="Macromates website">TextMate on OS X</a> has long been the favored Rails editor, but the classic editors are still going strong.
           <a href="http://www.vim.org/scripts/script.php?script_id=1567" title="Read more about VIM for rails">See VIM for Rails</a> and <a href="http://rinari.rubyforge.org/" title="Get Emacs for rails">Emacs for Rails</a>.
           For a full-on IDE, check out <a href="http://www.jetbrains.com/ruby/index.html" title="Ruby on rails IDE">JetBrains RubyMine</a>.

--- a/index.html
+++ b/index.html
@@ -6,101 +6,85 @@ subheader_3: "write beautiful code by favoring convention over configuration."
 ---
     <div class="container-fluid text-center">
       <div class="row">
-      <p id="announce">
+      <p id="announce" class="inverted">
         <a href="http://weblog.rubyonrails.org/2014/12/19/Rails-4-2-final/" title="Ruby on Rails Blog">Rails 4.2.0 has been released!</a>
       </p>
       </div>
-      <div id="slivers" class="row">
+      <div class="row smaller inverted slivers">
         <div class="container"><div class="row">
           <div class="col-sm-3 col-xs-6">
-            <h2>Get Excited</h2>
-            <a href="/screencasts/" title="Click for screencasts"><img src="/images/pages/overview/screencasts2.png" class="bordered" width="144" height="153" alt="Image representing a block of code"></a>
+            <h3>Get Excited</h3>
+            <a class="framed" href="/screencasts/" title="Click for screencasts"><img src="/images/pages/overview/screencasts2.png" width="144" height="153" alt="Image representing a block of code"></a>
             <p><a href="/screencasts/" title="Some screencasts about Rails">Screencasts &amp; presentations</a></p>
           </div>
           <div class="col-sm-3 col-xs-6">
-            <h2>Get Started</h2>
+            <h3>Get Started</h3>
             <a href="/download/" title="Download the Ruby on Rails last version"><img src="/images/pages/overview/download42.png" width="144" height="153" alt="Graphic showing a down arrow with the number of the latest stable version of Rails"></a>
             <p><a href="/download/" title="Download the Ruby on Rails last version">4.2.1 released Mar 19, 2015</a></p>
           </div>
           <div class="col-sm-3 col-xs-6">
-            <h2>Get Better</h2>
-            <a href="/documentation/" title="APIs, Books and Guides documentation about Ruby on Rails"><img src="/images/pages/documentation/awdr4.png" width="144" height="153" class="bordered" alt="Image showing the cover of the book Agile development with rails"></a>
+            <h3>Get Better</h3>
+            <a class="framed" href="/documentation/" title="APIs, Books and Guides documentation about Ruby on Rails"><img src="/images/pages/documentation/awdr4.png" width="144" height="153" alt="Image showing the cover of the book Agile development with rails"></a>
             <p><a href="/documentation/" title="APIs, Books and Guides documentation about Ruby on Rails">API, Guides, Books</a></p>
           </div>
           <div class="col-sm-3 col-xs-6">
-            <h2>Get Involved</h2>
+            <h3>Get Involved</h3>
             <a href="/community/" title="Join to the Ruby on Rails Community"><img src="/images/pages/overview/participate.gif" width="144" height="153" alt="Image showing a text bubble and the following words: IRC, Mailing list, bug tracker, wiki"></a>
             <p><a href="/community/" title="Join to the Ruby on Rails Community">Join the community</a></p>
           </div>
         </div></div>
       </div>
     </div>
-    <div class="container" id="slideshow">
+    <div class="container small inverted" id="slideshow">
         <blockquote>
-          <p>
             “Ruby on Rails is a breakthrough in lowering the barriers of entry to programming.<br class="hidden-xs" />
             Powerful web applications that formerly might have taken weeks or months<br class="hidden-xs" />
             to develop can be produced in a matter of days.”
-          </p>
-          <p><cite>– Tim O’Reilly, Founder of O’Reilly Media</cite></p>
+          <cite>– Tim O’Reilly, Founder of O’Reilly Media</cite>
         </blockquote>
         <blockquote style="display: none;">
-          <p>
             “Rails is the most well thought-out web development framework I’ve ever used.<br class="hidden-xs" />
             And that’s in a decade of doing web applications for a living. I’ve built my<br class="hidden-xs" />
             own frameworks, helped develop the Servlet API, and have created more than<br class="hidden-xs" />
             a few web servers from scratch. Nobody has done it like this before.”
-          </p>
-          <p><cite>– James Duncan Davidson, Creator of Tomcat and Ant</cite></p>
+          <cite>– James Duncan Davidson, Creator of Tomcat and Ant</cite>
         </blockquote>
         <blockquote style="display: none;">
-          <p>
             “It is impossible not to notice Ruby on Rails.  It has had a huge effect both in<br class="hidden-xs" />
             and outside the Ruby community... Rails has become a standard to which even<br class="hidden-xs" />
             well-established tools are comparing themselves to.”
-          </p>
-          <p><cite>– Martin Fowler, Author of Refactoring, PoEAA, XP Explained</cite></p>
+          <cite>– Martin Fowler, Author of Refactoring, PoEAA, XP Explained</cite>
         </blockquote>
         <blockquote style="display: none;">
-          <p>
             “What sets this framework apart from all of the others is the preference for<br class="hidden-xs" />
             convention over configuration making applications easier<br class="hidden-xs" />
             to develop and understand.”
-          </p>
-          <p><cite>– Sam Ruby, ASF board of directors</cite></p>
+          <cite>– Sam Ruby, ASF board of directors</cite>
         </blockquote>
         <blockquote style="display: none;">
-          <p>
             “Before Ruby on Rails, web programming required a lot of verbiage, steps and time.<br class="hidden-xs" />
             Now, web designers and software engineers can develop a website<br class="hidden-xs" />
             much faster and more simply, enabling them to be more productive<br class="hidden-xs" />
             and effective in their work.”
-          </p>
-          <p><cite>– Bruce Perens, Open Source Luminary</cite></p>
+          <cite>– Bruce Perens, Open Source Luminary</cite>
         </blockquote>
         <blockquote style="display: none;">
-          <p>
             “After researching the market, Ruby on Rails stood out as the best choice.<br class="hidden-xs" />
             We have been very happy with that decision.  We will continue<br class="hidden-xs" />
             building on Rails and consider it a key business advantage.”
-          </p>
-          <p><cite>– Evan Williams, Creator of Blogger and ODEO</cite></p>
+          <cite>– Evan Williams, Creator of Blogger and ODEO</cite>
         </blockquote>
         <blockquote style="display: none;">
-          <p>
             “Ruby on Rails is astounding. Using it is like watching a kung-fu movie,<br class="hidden-xs" />
             where a dozen bad-ass frameworks prepare to beat up the little newcomer<br class="hidden-xs" />
             only to be handed their asses in a variety of imaginative ways.”
-          </p>
-          <p><cite>– Nathan Torkington, O’Reilly Program Chair for OSCON</cite></p>
+          <cite>– Nathan Torkington, O’Reilly Program Chair for OSCON</cite>
         </blockquote>
         <blockquote style="display: none;">
-          <p>
             “Rails is the killer app for Ruby.”
-          </p>
-          <p><cite>– Yukihiro Matsumoto, Creator of Ruby</cite></p>
+          <cite>– Yukihiro Matsumoto, Creator of Ruby</cite>
         </blockquote>
-        <p class="more text-center"><a href="/quotes/" title="Read More quotes">Read more quotes</a></p>
+        <p class="text-center"><a href="/quotes/" title="Read More quotes"><em>Read more quotes</em></a></p>
       </div>
       <script type="text/javascript">
         $(function() {
@@ -121,28 +105,28 @@ subheader_3: "write beautiful code by favoring convention over configuration."
         });
       </script>
     <div class="container">
-      <div class="section row">
+      <div class="row">
       <div class="col-sm-4">
         <h2>Who is already<br class="hidden-xs" /> on Rails?</h2>
       </div>
       <div class="col-sm-8">
         <p>Tens of thousands of Rails applications are already live. People are using Rails in the tiniest part-time operations to the biggest companies.</p>
-        <div class="container-fluid text-center" id="used_by">
+        <div class="container-fluid text-center smaller">
         <div class="row">
-          <div class="col-sm-6">
-            <a href="http://www.basecamp.com/?source=rails" title="Basecamp: Project management app"><img width="179" height="114" src="/images/applications/bcx.gif" alt="Image showing Basecamp's index page" class="bordered"></a>
+          <div class="col-sm-6 text-center">
+            <a class="framed" href="http://www.basecamp.com/?source=rails" title="Basecamp: Project management app"><img width="179" height="114" src="/images/applications/bcx.gif" alt="Image showing Basecamp's index page" class="bordered"></a>
             <p><a href="http://www.basecamp.com/?source=rails" title="Basecamp: Project management app">Basecamp</a>: The original Rails app.</p>
           </div>
           <div class="col-sm-6">
-            <a href="http://twitter.com/" title="Twitter website"><img width="179" height="114" src="/images/applications/twitter.jpg" alt="Image showing Twitter's index page" class="bordered"></a>
+            <a class="framed" href="http://twitter.com/" title="Twitter website"><img width="179" height="114" src="/images/applications/twitter.jpg" alt="Image showing Twitter's index page" class="bordered"></a>
             <p><a href="http://twitter.com/" title="Twitter website">Twitter</a>: Stay connected.</p>
           </div>
           <div class="col-sm-6">
-            <a href="http://github.com/" title="Github build software better, together"><img width="179" height="114" src="/images/applications/github.jpg" alt="Image showing GitHub's index page" class="bordered"></a>
+            <a class="framed" href="http://github.com/" title="Github build software better, together"><img width="179" height="114" src="/images/applications/github.jpg" alt="Image showing GitHub's index page" class="bordered"></a>
             <p><a href="http://github.com/" title="Github build software better, together">GitHub</a>: Git repo hosting.</p>
           </div>
           <div class="col-sm-6">
-            <a href="http://www.shopify.com/" title="Shopify: e-commerce platform"><img width="179" height="114" src="/images/applications/shopify.jpg" alt="Shopify" class="bordered"></a>
+            <a class="framed" href="http://www.shopify.com/" title="Shopify: e-commerce platform"><img width="179" height="114" src="/images/applications/shopify.jpg" alt="Shopify" class="bordered"></a>
             <p><a href="http://www.shopify.com/" title="Shopify: e-commerce platform">Shopify</a>: E-commerce made easy.</p>
           </div>
         </div>
@@ -150,7 +134,7 @@ subheader_3: "write beautiful code by favoring convention over configuration."
       </div>
       </div>
 
-      <div class="section row">
+      <div class="row">
       <div class="col-sm-4">
         <h2>Who is<br class="hidden-xs" /> behind it?</h2>
       </div>

--- a/quotes/index.html
+++ b/quotes/index.html
@@ -6,66 +6,50 @@ subheader_2: "This is where we collect quotes from smart, famous,"
 subheader_3: "and/or funny people saying nice things about Rails."
 ---
       <blockquote>
-        <p>
           “Rails is the most well thought-out web development framework I’ve ever used.<br class="hidden-xs" />
           And that’s in a decade of doing web applications for a living. I’ve built my<br class="hidden-xs" />
           own frameworks, helped develop the Servlet API, and have created more than<br class="hidden-xs" />
           a few web servers from scratch. Nobody has done it like this before.”
-        </p>
-        <p><cite>– James Duncan Davidson, Creator of Tomcat and Ant</cite></p>
+        <cite>– James Duncan Davidson, Creator of Tomcat and Ant</cite>
       </blockquote>
       <blockquote>
-        <p>
           “Ruby on Rails is a breakthrough in lowering the barriers of entry to programming.<br class="hidden-xs" />
           Powerful web applications that formerly might have taken weeks or months<br class="hidden-xs" />
           to develop can be produced in a matter of days.”
-        </p>
-        <p><cite>– Tim O’Reilly, Founder of O’Reilly Media</cite></p>
+        <cite>– Tim O’Reilly, Founder of O’Reilly Media</cite>
       </blockquote>
       <blockquote>
-        <p>
           “It is impossible not to notice Ruby on Rails.  It has had a huge effect both in<br class="hidden-xs" />
           and outside the Ruby community... Rails has become a standard to which even<br class="hidden-xs" />
           well-established tools are comparing themselves to.”
-        </p>
-        <p><cite>– Martin Fowler, Author of Refactoring, PoEAA, XP Explained</cite></p>
+        <cite>– Martin Fowler, Author of Refactoring, PoEAA, XP Explained</cite>
       </blockquote>
       <blockquote>
-        <p>
           “What sets this framework apart from all of the others is the preference for<br class="hidden-xs" />
           convention over configuration making applications easier<br class="hidden-xs" />
           to develop and understand.”
-        </p>
-        <p><cite>– Sam Ruby, ASF board of directors</cite></p>
+        <cite>– Sam Ruby, ASF board of directors</cite>
       </blockquote>
       <blockquote>
-        <p>
           “Before Ruby on Rails, web programming required a lot of verbiage, steps and time.<br class="hidden-xs" />
           Now, web designers and software engineers can develop a website<br class="hidden-xs" />
           much faster and more simply, enabling them to be more productive<br class="hidden-xs" />
           and effective in their work.”
-        </p>
-        <p><cite>– Bruce Perens, Open Source Luminary</cite></p>
+        <cite>– Bruce Perens, Open Source Luminary</cite>
       </blockquote>
       <blockquote>
-        <p>
           “After researching the market, Ruby on Rails stood out as the best choice.<br class="hidden-xs" />
           We have been very happy with that decision.  We will continue<br class="hidden-xs" />
           building on Rails and consider it a key business advantage.”
-        </p>
-        <p><cite>– Evan Williams, Creator of Blogger and ODEO</cite></p>
+        <cite>– Evan Williams, Creator of Blogger and ODEO</cite>
       </blockquote>
       <blockquote>
-        <p>
           “Ruby on Rails is astounding. Using it is like watching a kung-fu movie,<br class="hidden-xs" />
           where a dozen bad-ass frameworks prepare to beat up the little newcomer<br class="hidden-xs" />
           only to be handed their asses in a variety of imaginative ways.”
-        </p>
-        <p><cite>– Nathan Torkington, O’Reilly Program Chair for OSCON</cite></p>
+        <cite>– Nathan Torkington, O’Reilly Program Chair for OSCON</cite>
       </blockquote>
       <blockquote>
-        <p>
           “Rails is the killer app for Ruby.”
-        </p>
-        <p><cite>– Yukihiro Matsumoto, Creator of Ruby</cite></p>
+        <cite>– Yukihiro Matsumoto, Creator of Ruby</cite>
       </blockquote>

--- a/screencasts/index.html
+++ b/screencasts/index.html
@@ -6,14 +6,14 @@ subheader_2: "former treadmill after being exposed to these movies can prove"
 subheader_3: "exceedingly painful. Don’t say we didn’t try to warn you."
 ---
     <div class="container">
-      <div class="section row">
-      <div class="col-sm-4">
-        <a href="http://railsforzombies.org" class="screencast" title="Code school about Rails">
-          <img src="/images/pages/screencasts/Rails_for_Zombies-2.jpg" alt="Rails for zombies">
+      <div class="row">
+      <div class="col-sm-4"><div class="row">
+        <a href="http://railsforzombies.org" title="Code school about Rails">
+          <img class="screencast" src="/images/pages/screencasts/Rails_for_Zombies-2.jpg" alt="Rails for zombies">
         </a>
-        </div>
+        </div></div>
         <div class="col-sm-8">
-        <h3>Learning Rails the Zombie Way</h3>
+        <h5>Learning Rails the Zombie Way</h5>
         <p>
           If you’re new to Rails and want to give it a try, then head over to
           <a href="http://railsforzombies.org" title="Code school about Rails ">RailsForZombies.org</a>. Rails for Zombies is
@@ -29,14 +29,14 @@ subheader_3: "exceedingly painful. Don’t say we didn’t try to warn you."
         </div>
       </div>
 
-      <div class="section row">
-        <div class="col-sm-4">
-        <a href="http://rails4.codeschool.com/videos" class="screencast" title="Rails 4 videos">
-          <img src="/images/pages/screencasts/rails4_zombie_outlaws.jpg" alt="Rails 4 zombie outlaws">
+      <div class="row">
+        <div class="col-sm-4"><div class="row">
+        <a href="http://rails4.codeschool.com/videos" title="Rails 4 videos">
+          <img class="screencast" src="/images/pages/screencasts/rails4_zombie_outlaws.jpg" alt="Rails 4 zombie outlaws">
         </a>
-        </div>
+        </div></div>
         <div class="col-sm-8">
-        <h3>Rails 4: Zombie Outlaws</h3>
+        <h5>Rails 4: Zombie Outlaws</h5>
         <p>
           If you’re looking to get your hands dirty with the newest version of Rails, the
           <a href="http://rails4.codeschool.com/videos" title="Rails 4 videos">Rails 4: Zombie Outlaw Videos</a>
@@ -50,14 +50,14 @@ subheader_3: "exceedingly painful. Don’t say we didn’t try to warn you."
         </div>
       </div>
 
-      <div class="section row">
-        <div class="col-sm-4">
-        <a href="http://railscasts.com" class="screencast" title="Click to access to Rails Casts">
-          <img src="/images/pages/screencasts/railscasts.png" alt="Rails casts">
+      <div class="row">
+        <div class="col-sm-4"><div class="row">
+        <a href="http://railscasts.com" title="Click to access to Rails Casts">
+          <img class="screencast" src="/images/pages/screencasts/railscasts.png" alt="Rails casts">
         </a>
-        </div>
+        </div></div>
         <div class="col-sm-8">
-        <h3>More free screencasts from Railscasts.com</h3>
+        <h5>More free screencasts from Railscasts.com</h5>
         <p>
           If the screencast above got you interested in learning more by video, you can
           find a treasure trove of great content at <a href="http://www.railscasts.com" title="Ruby on rails screencasts">Railscasts.com</a>.

--- a/security/index.html
+++ b/security/index.html
@@ -6,7 +6,7 @@ subheader_2: "If you found a vulnerability in Ruby on Rails, follow"
 subheader_3: "these steps to safely report the issue to the core team."
 ---
     <div class="container">
-      <div class="section row">
+      <div class="row">
       <div class="col-sm-4">
       <h2>Supported versions</h2>
       </div>
@@ -16,12 +16,12 @@ subheader_3: "these steps to safely report the issue to the core team."
         security issues, and severe security issues. They are handled as follows:
       </p>
 
-    	<h3>New Features</h3>
+    	<h5>New Features</h5>
     	<p>
         New Features are only added to the master branch and will not be made available in point releases.
       </p>
 
-    	<h3>Bug fixes</h3>
+    	<h5>Bug fixes</h5>
     	<p>
         Only the latest release series will receive bug fixes. When enough bugs are fixed and
         its deemed worthy to release a new gem, this is the branch it happens from.
@@ -31,7 +31,7 @@ subheader_3: "these steps to safely report the issue to the core team."
       	<li>Current release series: 4.2.x</li>
       </ul>
 
-    	<h3>Security issues:</h3>
+    	<h5>Security issues:</h5>
     	<p>
         The current release series and the next most recent one will receive patches
         and new versions in case of a security issue.
@@ -42,7 +42,7 @@ subheader_3: "these steps to safely report the issue to the core team."
         <li>Next most recent release series: 4.1.x</li>
       </ul>
 
-    	<h3>Severe security issues:</h3>
+    	<h5>Severe security issues:</h5>
     	<p>
         For severe security issues we will provide new versions as above, and
         also the last major release series will receive patches and new versions.
@@ -55,7 +55,7 @@ subheader_3: "these steps to safely report the issue to the core team."
         <li>Last major release series: 3.2.x</li>
       </ul>
 
-    	<h3>Unsupported Release Series</h3>
+    	<h5>Unsupported Release Series</h5>
       <p>
         When a release series is no longer supported, it’s your own responsibility
         to deal with bugs and security issues. We may provide back-ports of the
@@ -66,7 +66,7 @@ subheader_3: "these steps to safely report the issue to the core team."
       </div>
     </div>
 
-    <div class="section row">
+    <div class="row">
       <div class="col-sm-4">
     	<h2>Reporting a bug</h2>
       </div>
@@ -107,7 +107,7 @@ subheader_3: "these steps to safely report the issue to the core team."
       </div>
     </div>
 
-    <div class="section row">
+    <div class="row">
       <div class="col-sm-4">
     	<h2>Disclosure Policy</h2>
       </div>
@@ -158,7 +158,7 @@ subheader_3: "these steps to safely report the issue to the core team."
       </div>
     </div>
 
-    <div class="section row">
+    <div class="row">
       <div class="col-sm-4">
     	<h2>Receiving Security Updates</h2>
       </div>
@@ -181,7 +181,7 @@ subheader_3: "these steps to safely report the issue to the core team."
       </div>
     </div>
 
-    <div class="section row">
+    <div class="row">
       <div class="col-sm-4">
     	<h2>Comments on this Policy</h2>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -1,267 +1,119 @@
-/* Site */
-body {
-	background: #fff url(images/topbluefade.gif) repeat-x center top;
-	color: #333;
-	font-family: Verdana, Lucida Grande, Arial, Helvetica, sans-serif;
-	font-size: 14px;
-	line-height: 18px;
-	margin: 0px;
-	padding: 0px;
-}
-sup {
-  line-height: 0;
-}
-a img {
-	border: none;
-}
-a.nohover {
-	background-color: transparent !important;
-}
-a.align-right {
-	float: right;
-	margin: 0px 0px 0px 10px;
-}
-a.align-right img {
-	display: block;
-}
-a.align-center {
-	display: inline-block;
-	margin: 0px 5px;
-}
-a.align-center img {
-	display: block;
-}
-ul, ol {
-  margin-left: 250px;
-}
-img.bordered {
-	background-color: #fff;
-	border: 1px solid #CCC;
-	padding: 1px;
-}
-img.align-right {
-	float: right;
-	margin: 0px 0px 0px 10px;
-}
-span.highlight {
-	background-color: #ffc;
-}
-div.section h2 {
-	font-family: Georgia;
-	font-size: 28px;
-
-	font-weight: normal;
-	line-height: 120%;
-  margin: 0 10px 20px 0;
-}
-@media (min-width:768px) {
-  section h2.small { font-size: 20px; }
-}
-@media (max-width:768px) {
-  section h2 { text-align: center; }
-}
-div.section h3 {
-	color: #900;
-	font-family: Georgia;
-	font-size: 18px;
-  margin: 0 10px 0px 10px;
-	line-height: 140%;
-}
-div.section ul, div.section ol {
-  margin: 0 10px 14px 10px;
-}
-div.section p {
-  font-family: Georgia;
-  font-size: 18px;
-  line-height: 140%;
-  margin: 0 10px 25px 10px;
-}
-@media (min-width: 768px) {
-div.section p.small {
-	font-size: 14px;
-}
-}
-div.section pre {
-  margin: 0 10px 25px 10px;
-}
-@media (min-width: 768px) {
-  div.section pre { margin-left: 35px;}
-}
-
-@media (min-width: 768px) {
-div.section p.footnote {
-	font-size: 12px;
-}
-}
-div.section img.biopic {
-	background-color: #fff;
-	border: 2px solid #ccc;
-	padding: 2px;
-  margin-top: 0; margin-bottom: 6px;
-  width: 158px;
-  height: 180px;
-  margin-right: 12px; margin-left: 35px;
-}
-
-div.section a.screencast {
-  margin: 0;
-}
-div.section a.screencast img {
-	background-color: #fff;
-	border: 2px solid #ccc;
-	padding: 2px;
-  width: 198px;
-  height: 158px;
-  margin-right: 12px; margin-left: 35px;
-}
-div.section code {
-	font-family: Courier New, Courier, mono;
-	font-size: 16px;
-	font-weight: bold;
-}
-#article {
-	padding: 0px 0px 20px 0px;
-}
-#article p a,
-#article ol a,
-#article ul a {
-	color: #369;
-}
-#article p a:hover,
-#article ol a:hover,
-#article ul a:hover {
-	background-color: #f4dda6;
-	text-decoration: none;
-}
-#article p.missing {
-	color: #000;
-	font-family: Georgia;
-	font-size: 28px;
-	font-weight: normal;
-	line-height: 120%;
-}
-#sponsored_by {
-	margin: 17px 0px !important;
-}
-#sponsored_by a:hover {
-	background-color: transparent !important;
-}
-#sponsored_by a img {
-	vertical-align: -7px;
-}
-
-#used_by p {
-	font-size: 10px;
-	font-family: inherit;
-}
-
-/* Quotes */
-blockquote {
-  font-family: Georgia;
-  font-size: 18px;
-  text-align: center;
-  margin: 0px auto 25px;
-  line-height: 140%;
-}
-
-blockquote p {
-	margin: 0px;
-}
-
-cite {
-  font-size: 14px;
-	color: #a69e8a;
-}
-
-/* The following rules override values set by Bootstrap CSS, ensuring that
-   the site looks the same whether or not Bootstrap CSS is loaded. */
-
-a                                                   {text-decoration: underline}
-code                                                {background-color: transparent; color: #000; padding-left: 0; padding-right: 0}
-pre                                                 {background-color: transparent; border: 0; padding: 0}
-h3                                                  {font-weight: bold}
-img                                                 {vertical-align: baseline}
-ul, ol                                              {margin-bottom: 14px}
-blockquote                                          {border-left: 0; padding: 0}
-
-/* TYPOGRAPHY */
-header                                              {font-family: "expressway", sans-serif; font-style: normal}
-#slivers h2, #slideshow                             {font-family: Georgia}
-#slivers h2                                         {font-size: 22px; line-height: 24px; font-weight: normal}
-.navbar-nav, footer                                 {font-size: 11px}
-.navbar-nav a                                       {font-weight: bold}
-footer a:focus, footer a:hover                      {text-decoration: none}
-#slideshow blockquote                               {font-size: 16px}
-#slideshow p.more                                   {font-size: 14px; font-style: italic}
-
-footer                                              {text-align: center}
-#announce                                           {font-size: 11px; line-height: 13px}
-#slivers p                                          {font-size: 10px}
-h1                                                  {font-size: 38px; line-height: 30px; font-weight: 700}
-header h2                                           {font-size: 21px; line-height: 24px; font-weight: 400}
-@media (max-width: 768px) {
-  h1                                                {font-size: 31px}
-  header h2                                         {font-size: 18px}
-}
-
+ /* TYPOGRAPHY */
+body                                                {font-family: Georgia, serif}
+header                                              {font-family: "expressway", sans-serif}
+code                                                {font-family: Courier New, Courier, mono}
+#announce, .smaller p, footer, ul, ol               {font-family: Verdana, Lucida Grande, Arial, Helvetica, sans-serif}
+h1                                                  {font-size: 38px}
+h2                                                  {font-size: 28px}
+h3                                                  {font-size: 22px}
+h4                                                  {font-size: 21px}
+.small h2                                           {font-size: 20px}
+h5, p, blockquote                                   {font-size: 18px}
+code, pre code, .small blockquote                   {font-size: 16px}
+.small p, cite                                      {font-size: 14px}
+.footnote                                           {font-size: 12px}
+nav, footer p, #announce                            {font-size: 11px}
+.smaller p                                          {font-size: 10px}
+@media (max-width: 767px) {h1                       {font-size: 31px}}
+@media (max-width: 767px) {h4                       {font-size: 18px}}
+h1, h5, code, nav                                   {font-weight: bold}
+h2, h3                                              {font-weight: normal}
+h1                                                  {line-height: 30px}
+h4, h3                                              {line-height: 24px}
+body, footer p                                      {line-height: 18px}
+h5, p, blockquote                                   {line-height: 140%}
+h2                                                  {line-height: 120%}
 .col-sm-4                                           {text-align: right}
-@media (max-width: 768px) {
-  .col-sm-4, h3                                         {text-align: center}
-}
+footer, blockquote, #menu                           {text-align: center}
+@media (max-width:767px) {h2, h5, .col-sm-4         {text-align: center}}
+a                                                   {text-decoration: underline}
+a:focus, a:hover                                    {text-decoration: none}
 
-/* COLOR AND BACKGROUND */
+/* BACKGROUNDS */
+body                                                {background-image: url(images/topbluefade.gif); background-repeat: repeat-x}
+.slivers                                            {background-image: url(images/herobackground.gif)}
+@media (min-width: 768px) {header.container         {background-image: url(images/rails.png); background-repeat: no-repeat; background-position: 22px 0px}}
+
+/* COLORS */
+a                                                   {color: #369}
+a:hover, a:focus                                    {background-color: #f4dda6}
+mark                                                {background-color: #ffc}
 footer                                              {color: #666}
-header h2                                           {color: #999}
-p#announce                                          {color: #fff; background-color: #981a21}
-p#announce a                                        {color: #fff}
-#slivers h2                                         {color: #0e3062}
-#slideshow cite, #slideshow p.more a                {color: #464242}
-p#announce a:hover, p#announce a:focus,
-#slivers p a:hover, #slivers p a:focus,
-#slideshow p a:hover, #slideshow p a:focus          {color: #fff; background-color: #000}
-#slivers                                            {border-top-color: #f6e69f; border-top-style: solid; border-bottom-color: #f6e69f; border-bottom-style: solid; background: url(images/herobackground.gif) left top}
-.navbar-default                                     {background-color: transparent; border-color: transparent}
-.navbar-default .navbar-nav>li>a, footer a, h1,
-#slivers p a                                        {color: #000}
-.navbar-default .navbar-nav>li>a:focus,
-footer a:focus, footer a:hover,
-.navbar-default .navbar-nav>li>a:hover              {color: #fff; background-color: #333}
-.navbar-collapse.in                                 {border-bottom-color: #e7e7e7; border-bottom-style: solid}
-.collapse:not(.in) .navbar-nav li:not(:last-child)  {border-right-color: #000; border-right-style: solid}
+#menu a, code, pre, footer a                        {color: #000}
+#menu a:focus, #menu a:hover                        {color: #fff; background-color: #333}
+.navbar-default, code, pre                          {background-color: transparent}
+.navbar                                             {border-color: transparent}
+h4                                                  {color: #999}
+.framed img, .col-sm-4 img                          {background-color: #fff; border-color: #ccc}
+h5                                                  {color: #900}
+cite                                                {color: #a69e8a}
+#announce                                           {background-color: #981a21}
+#announce a, .inverted a:hover, .inverted a:focus   {color: #fff}
+.slivers                                            {border-top-color: #f6e69f; border-bottom-color: #f6e69f}
+.slivers a                                          {color: #000}
+.inverted a:hover, .inverted a:focus                {background-color: #000}
+#slideshow cite, #slideshow a                       {color: #464242}
 
-/* VERTICAL LAYOUT */
-.navbar-nav>li>a                                    {padding-top: 0; padding-bottom: 0}
-.navbar-nav li                                      {margin-top: 10px; margin-bottom: 15px}
-.navbar-collapse.in                                 {border-bottom-width: 1px}
-footer                                              {padding-bottom: 44px}
-footer p                                            {margin-top: 12px}
-footer p, h1                                        {margin-bottom: 12px}
-.navbar-brand                                       {padding-top: 8px}
+/* BORDERS */
+#menu.in                                            {border-bottom-style: solid}
+#menu:not(.in) li:not(:last-child)                  {border-right-style: solid}
+.framed img, .col-sm-4 img                          {border-style: solid}
+.slivers                                            {border-top-style: solid; border-bottom-style: solid}
+
+/* LAYOUTS */
+cite                                                {display: block}
+@media (min-width: 768px) {.navbar .navbar-nav      {display: inline-block; float: none}}
+@media (min-width: 768px) {.navbar-brand            {display: none}}
+
+/* WIDTHS */
+img.screencast                                      {width: 198px}
+img.biopic                                          {width: 158px; margin-right: 12px}
+@media (min-width:992px)  {.container               {width: 750px}}
+@media (min-width:992px)  {.slivers .container      {width: 792px}}
+#menu:not(.in) li                                   {padding-left: 5px; padding-right: 5px}
+#menu:not(.in) li:not(:last-child)                  {border-right-width: 1px}
+#menu a , mark, code, pre                           {padding-left: 0; padding-right: 0}
+@media (min-width: 768px) {header.container         {padding-left: 115px}}
+h2, .col-sm-8 p, h5, ul, ol                         {margin-right: 10px}
+pre                                                 {border-left: 0; border-right: 0; margin-left: 35px}
+@media (max-width: 767px) {pre                      {margin-left: 10px}}
+.framed img                                         {padding-left: 1px; padding-right: 1px; border-left-width: 1px; border-right-width: 1px}
+.col-sm-4 img                                       {padding-left: 2px; padding-right: 2px; border-left-width: 2px; border-right-width: 2px}
+.col-sm-4 a                                         {margin-right: 2px}
+.col-sm-8 .framed, .col-sm-8 p, h5, ul, ol          {margin-left: 10px}
+.col-sm-6 .framed                                   {margin-left: 0px}
+.col-sm-6 .framed img                               {margin-bottom: 4px}
+blockquote                                          {border-left-width: 0}
+
+/* HEIGHTS */
+img.screencast                                      {height: 158px}
+img.biopic                                          {height: 180px; margin-bottom: 10px}
 .navbar-brand img                                   {height: 34px}
+#menu li                                            {margin-top: 10px; margin-bottom: 13px}
+#menu a, mark, pre, blockquote                      {padding-top: 0; padding-bottom: 0}
+.navbar-brand                                       {padding-top: 8px}
+#menu.in                                            {border-bottom-width: 1px}
 header                                              {margin-top: 27px; margin-bottom: 32px}
-h1, header h2                                       {margin-top: 0}
-header h2, #announce                                {margin-bottom: 0}
-#announce                                           {padding-top: 5px; padding-bottom: 5px}
-#slivers p                                          {margin-top: 2px; margin-bottom: 25px}
-#slivers h2                                         {margin-top: 10px}
-#slivers                                            {border-top-width: 2px; border-bottom-width: 2px}
-#slideshow                                          {margin-top: 16px; margin-bottom: 22px}
+h1, h2, h5                                          {margin-top: 0}
+h2, article                                         {margin-bottom: 20px}
+.col-sm-8 p                                         {margin-bottom: 25px}
+h1                                                  {margin-bottom: 12px}
+h4, h5, #announce                                   {margin-bottom: 0px}
+pre                                                 {border-top: 0; border-bottom: 0}
+pre, blockquote                                     {margin-bottom: 25px}
+footer                                              {padding-bottom: 44px}
+footer p                                            {margin-bottom: 12px; margin-top: 12px}
+#sponsored_by                                       {margin-bottom: 17px; margin-top: 17px}
+#sponsored_by img                                   {vertical-align: -7px}
+.framed img                                         {padding-top: 1px; padding-bottom: 1px; border-top-width: 1px; border-bottom-width: 1px}
+.col-sm-4 img                                       {padding-top: 2px; padding-bottom: 2px}
+.col-sm-4 img, .slivers                             {border-top-width: 2px; border-bottom-width: 2px}
+ul, ol                                              {margin-bottom: 14px}
+cite                                                {margin-top: 2px}
+#announce                                           {padding-top: 4px; padding-bottom: 4px}
+h3                                                  {margin-top: 10px}
+.slivers p                                          {margin-top: 8px; margin-bottom: 27px}
+.slivers                                            {margin-bottom: 16px}
 #slideshow blockquote                               {height: 87px}
-@media (max-width: 768px) {
-  #slideshow blockquote                             {height: 200px}
-}
-
-/* HORIZONTAL LAYOUT */
-.navbar-nav>li>a                                    {padding-left: 0; padding-right: 0}
-.collapse:not(.in) .navbar-nav li                   {padding-left: 5px; padding-right: 5px}
-.collapse:not(.in) .navbar-nav li:not(:last-child)  {border-right-width: 1px}
-@media (min-width: 768px) { /* center the navbar, see stackoverflow.com/a/18778769 */
-  .navbar .navbar-nav                               {display: inline-block; float: none; vertical-align: top}
-  .navbar .navbar-collapse                          {text-align: center}
-  .navbar-brand                                     {display: none}
-  header.container                                  {background: url(images/rails.png) no-repeat 22px top; padding-left: 115px;}
-}
-@media (min-width:992px)  { /* Reduce width on big screens */
-  .container                                        {width: 750px}
-  #slivers .container                               {width: 792px}
-}
+@media (max-width: 767px) {#slideshow blockquote    {height: 200px}}
+#slideshow                                          {margin-bottom: 21px}


### PR DESCRIPTION
This commit "flips the switch" of using an adaptive viewport on smaller devices which (combined with the most recent commits) makes the site looks nicer on narrow screens by means of Boostrap’s adaptive grid.

Additionally, this commit cleans up the CSS / markup by removing DOM elements that are not required anymore (e.g. `<div id="article">`), using more semantic elements (e.g., `<mark>` replaces `<div class="highlight">`).

The site should look the same when seen on big screens, but should provide a better experience on smaller screens.

Closes #46