### PR TITLE
Move the code of conduct to the main website

### DIFF
--- a/conduct/index.html
+++ b/conduct/index.html
@@ -1,0 +1,86 @@
+---
+title: "Code of Conduct"
+header: "Code of Conduct"
+subheader_1: "Rails is committed to fostering a welcoming community."
+subheader_2: "If you encounter any unacceptable behavior, follow these steps"
+subheader_3: "to report the issue to the core team. We are here to help."
+---
+    <div class="container">
+      <div class="row">
+      <div class="col-sm-4">
+      <h2>Code of Conduct</h2>
+      </div>
+      <div class="col-sm-8">
+      <p>
+        As contributors and maintainers of this project, and in the interest of
+        fostering an open and welcoming community, we pledge to respect all people
+        who contribute through reporting issues, posting feature requests, updating
+        documentation, submitting pull requests or patches, and other activities.
+      </p>
+
+      <p>
+        We are committed to making participation in this project a harassment-free
+        experience for everyone, regardless of level of experience, gender, gender
+        identity and expression, sexual orientation, disability, personal appearance,
+        body size, race, ethnicity, age, religion, or nationality.
+      </p>
+
+      <p>
+        Examples of unacceptable behavior by participants include:
+      </p>
+
+      <ul>
+        <li>The use of sexualized language or imagery</li>
+        <li>Personal attacks</li>
+        <li>Trolling or insulting/derogatory comments</li>
+        <li>Public or private harassment</li>
+        <li>Publishing other's private information, such as physical or electronic addresses, without explicit permission</li>
+        <li>Other unethical or unprofessional conduct.</li>
+      </ul>
+
+      <p>
+        The Rails core team have the right and responsibility to remove, edit, or
+        reject comments, commits, code, wiki edits, issues, and other contributions
+        that are not aligned to this Code of Conduct.
+      </p>
+
+      <p>
+        We commit to fairly and consistently applying these principles to every aspect
+        of managing this project. Project maintainers who do not follow or enforce the
+        Code of Conduct may be permanently removed from the project team.
+      </p>
+
+      <p>
+        This code of conduct applies both within project spaces and in public spaces
+        when an individual is representing the project or its community.
+      </p>
+
+      <p>
+        <em>This Code of Conduct is adapted from the <a href="http://contributor-covenant.org/version/1/2/0/">Contributor Covenant, version 1.2.0</a>.</em>
+      </p>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-4">
+    	<h2>Reporting Issues</h2>
+      </div>
+      <div class="col-sm-8">
+      <p>
+        Instances of abusive, harassing, or otherwise unacceptable behavior should be
+        reported by sending an email to (<a href="mailto:conduct@rubyonrails.org">conduct@rubyonrails.org</a>).
+        We are here to help.
+      </p>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-4">
+    	<h2>Revisions</h2>
+      </div>
+      <div class="col-sm-8">
+      <p>
+        For a history of updates and revisions to this policy, see the <a href="https://github.com/rails/rails.github.com/commits/master/conduct/index.html">page history</a>.
+      </p>
+      </div>
+    </div>


### PR DESCRIPTION
Once this is merged, I'll edit the text in our projects to link to this page, so we only maintain one copy ([alas Ember](https://github.com/emberjs/ember.js/blob/master/CODE_OF_CONDUCT.md))

This would live on http://rubyonrails.org/conduct once merged