### PR TITLE
Make sure Code of Conduct protects atheists

### DIFF
--- a/conduct/index.html
+++ b/conduct/index.html
@@ -22,7 +22,7 @@ subheader_3: "to report the issue to the core team. We are here to help."
         We are committed to making participation in this project a harassment-free
         experience for everyone, regardless of level of experience, gender, gender
         identity and expression, sexual orientation, disability, personal appearance,
-        body size, race, ethnicity, age, religion, or nationality.
+        body size, race, ethnicity, age, religion or lack thereof, or nationality.
       </p>
 
       <p>


### PR DESCRIPTION
Newly approved Code of Conduct mentions religion, but big share of Rails developers and contributors are atheists or agnostic. I come from society that was very tolerant towards various religions throughout ages. In my home country (Poland) Christians, Jews and Muslims lived together for hundreds of years and freedom of religion was protected by law.

This, never applied to atheists, however. They were prosecuted and executed. Notable example includes Kazimierz Łyszczyński https://en.wikipedia.org/wiki/Kazimierz_%C5%81yszczy%C5%84ski.

Modern societies of many countries exhibit prejudice, violence and lack of tolerance towards atheists. This does not include only Muslim states of Pakistan, Quatar or Saudi Arabia, that would be an obvious example. This includes also USA and many European countries, where atheists are being discriminated by society, law and government. An atheist would not stand a chance in presidential elections in USA, for example.

Since Rails declares to protect religious contributors from harassment, it is only fair that us, non-religious people of different cultures, races, body sizes etc. get appropriate protection too.

This patch changes "religion" to "religion or lack thereof" to ensure that we get fair treatment. 

 